### PR TITLE
Fix optimistic card removal bug and unskip E2E trick test

### DIFF
--- a/apps/client/src/components/game/PlayerHand.tsx
+++ b/apps/client/src/components/game/PlayerHand.tsx
@@ -60,6 +60,7 @@ export function PlayerHand({
                 onClick={() => handleCardClick(card)}
                 disabled={!isMyTurn}
                 selected={isSelected}
+                testId="hand-card"
               />
             )}
           </div>

--- a/apps/client/src/components/ui/Card.tsx
+++ b/apps/client/src/components/ui/Card.tsx
@@ -7,6 +7,7 @@ interface CardProps {
   disabled?: boolean;
   selected?: boolean;
   small?: boolean;
+  testId?: string;
 }
 
 const SUIT_SYMBOLS: Record<Suit, string> = {
@@ -23,7 +24,7 @@ const SUIT_COLORS: Record<Suit, string> = {
   clubs: '#1a1a2e'
 };
 
-export function Card({ card, onClick, disabled, selected, small }: CardProps) {
+export function Card({ card, onClick, disabled, selected, small, testId }: CardProps) {
   const symbol = SUIT_SYMBOLS[card.suit];
   const color = SUIT_COLORS[card.suit];
 
@@ -31,6 +32,7 @@ export function Card({ card, onClick, disabled, selected, small }: CardProps) {
     <button
       onClick={onClick}
       disabled={disabled}
+      data-testid={testId}
       style={{
         width: small ? '50px' : '70px',
         height: small ? '75px' : '100px',

--- a/apps/client/src/hooks/use-game.ts
+++ b/apps/client/src/hooks/use-game.ts
@@ -29,6 +29,10 @@ export function useGame() {
       store.setHand(hand);
     });
 
+    socket.on('game:card-played', ({ card }) => {
+      store.removeCard(card);
+    });
+
     socket.on('game:trick-won', ({ winnerId }) => {
       store.setTrickWinner(winnerId);
       setTimeout(() => store.clearTrickWinner(), 2000);
@@ -63,6 +67,7 @@ export function useGame() {
       socket.off('room:joined');
       socket.off('game:state-update');
       socket.off('game:cards-dealt');
+      socket.off('game:card-played');
       socket.off('game:trick-won');
       socket.off('game:round-end');
       socket.off('game:ended');
@@ -110,7 +115,6 @@ export function useGame() {
   const playCard = useCallback((card: Card) => {
     if (!socket) return;
     socket.emit('game:play-card', { card });
-    store.removeCard(card);
   }, [socket]);
 
   const leaveRoom = useCallback(() => {

--- a/e2e/helpers/playing-helpers.ts
+++ b/e2e/helpers/playing-helpers.ts
@@ -3,30 +3,13 @@ import type { Page } from '@playwright/test';
 /**
  * Plays the first available (non-disabled) card on the given page.
  * The page must be showing "Your turn!".
- *
- * NOTE: This works reliably for the first play in a trick (no TrickArea cards yet).
- * For subsequent plays within a trick, TrickArea also renders non-disabled <Card>
- * buttons that can match the same selector. See full-game.spec.ts comments for details
- * on approaches to fix multi-play scenarios.
  */
 export async function playFirstCard(page: Page): Promise<void> {
   await page.getByText('Your turn!').waitFor({ timeout: 15_000 });
 
-  // Find the first enabled card button in the hand area.
-  // Cards are <button> elements containing rank + suit spans.
-  const cards = page.locator('button:not([disabled])').filter({
-    has: page.locator('span'),
-  });
-
-  // Click the first card that looks like a playing card (has 2 spans: rank + suit)
-  const cardButtons = await cards.all();
-  for (const card of cardButtons) {
-    const spans = await card.locator('span').count();
-    if (spans === 2) {
-      await card.click();
-      break;
-    }
-  }
+  // Use data-testid to reliably target hand cards (not trick area cards)
+  const card = page.locator('[data-testid="hand-card"]:not([disabled])').first();
+  await card.click();
 
   // Wait for the Play button to appear and click it
   const playButton = page.getByRole('button', { name: /^Play .+ of .+$/ });

--- a/e2e/tests/card-playing.spec.ts
+++ b/e2e/tests/card-playing.spec.ts
@@ -16,14 +16,7 @@ test.describe('Card Playing', () => {
     await expect(activePlayer.getByRole('button', { name: /^Play .+ of .+$/ })).not.toBeVisible({ timeout: 5_000 });
   });
 
-  /**
-   * SKIPPED: Same race condition as full-game tests — see full-game.spec.ts for details.
-   * The TrickArea renders played cards as non-disabled <Card> buttons. After the first
-   * play, playFirstCard() can match a TrickArea card instead of a hand card, causing
-   * the Play confirmation button to never appear. Needs data-testid attributes or
-   * a scoped locator approach to reliably distinguish hand cards from trick area cards.
-   */
-  test.skip('complete a full trick with 4 card plays', async ({ fourPlayerBidding }) => {
+  test('complete a full trick with 4 card plays', async ({ fourPlayerBidding }) => {
     const { players } = fourPlayerBidding;
 
     await completeAllBids(players, 3);


### PR DESCRIPTION
## Summary
- **Fix client bug**: `playCard()` optimistically removed cards from the hand before server confirmation. If the server rejected the play (e.g., out-of-turn), the card was permanently lost with no rollback. Now cards are only removed via the `game:card-played` server event.
- **Add `data-testid="hand-card"`** to PlayerHand's Card elements so E2E tests can reliably distinguish hand cards from TrickArea cards.
- **Unskip "complete a full trick" E2E test** which now passes thanks to both fixes above.
- **Update full-game test skip comments** to document the new blocker (RoundSummaryModal not appearing after 13 tricks — separate issue).

## Test plan
- [x] All 56 unit tests pass
- [x] 18 E2E tests pass, 2 skipped (full-game round-summary — pre-existing, separate issue)
- [x] Previously-skipped "complete a full trick with 4 card plays" test now passes
- [ ] Manual smoke test: play a card out-of-turn and verify it stays in hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)