### PR TITLE
feat(client): disable unplayable cards in hand

### DIFF
--- a/apps/client/src/components/game/PlayerHand.tsx
+++ b/apps/client/src/components/game/PlayerHand.tsx
@@ -9,6 +9,7 @@ interface PlayerHandProps {
   selectedCard: CardType | null;
   onSelectCard: (card: CardType | null) => void;
   faceDown?: boolean;
+  playableCards?: CardType[];
 }
 
 export function PlayerHand({
@@ -17,10 +18,17 @@ export function PlayerHand({
   isMyTurn,
   selectedCard,
   onSelectCard,
-  faceDown = false
+  faceDown = false,
+  playableCards
 }: PlayerHandProps) {
+  const isCardPlayable = (card: CardType): boolean => {
+    if (!isMyTurn) return false;
+    if (!playableCards) return true;
+    return playableCards.some(c => c.suit === card.suit && c.rank === card.rank);
+  };
+
   const handleCardClick = (card: CardType) => {
-    if (!isMyTurn) return;
+    if (!isCardPlayable(card)) return;
 
     if (selectedCard && selectedCard.suit === card.suit && selectedCard.rank === card.rank) {
       // Double click to play
@@ -58,7 +66,7 @@ export function PlayerHand({
               <Card
                 card={card}
                 onClick={() => handleCardClick(card)}
-                disabled={!isMyTurn}
+                disabled={!isCardPlayable(card)}
                 selected={isSelected}
                 testId="hand-card"
               />

--- a/packages/shared/src/__tests__/play-validator.test.ts
+++ b/packages/shared/src/__tests__/play-validator.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { validatePlay, getPlayableCards } from '../validation/play-validator';
+import type { PlayValidationGameState } from '../validation/play-validator';
+import type { Card } from '../types/card';
+
+function makeGameState(overrides: Partial<PlayValidationGameState> = {}): PlayValidationGameState {
+  return {
+    phase: 'playing',
+    players: [
+      { id: 'p1', position: 0 },
+      { id: 'p2', position: 1 },
+      { id: 'p3', position: 2 },
+      { id: 'p4', position: 3 },
+    ],
+    currentPlayerPosition: 0,
+    currentRound: {
+      currentTrick: { plays: [], leadSuit: null },
+      spadesBroken: false,
+    },
+    ...overrides,
+  };
+}
+
+const heartA: Card = { suit: 'hearts', rank: 'A' };
+const heartK: Card = { suit: 'hearts', rank: 'K' };
+const heart5: Card = { suit: 'hearts', rank: '5' };
+const spadeA: Card = { suit: 'spades', rank: 'A' };
+const spadeK: Card = { suit: 'spades', rank: 'K' };
+const spade5: Card = { suit: 'spades', rank: '5' };
+const clubA: Card = { suit: 'clubs', rank: 'A' };
+const club5: Card = { suit: 'clubs', rank: '5' };
+const diamondA: Card = { suit: 'diamonds', rank: 'A' };
+
+describe('validatePlay', () => {
+  it('rejects when not in playing phase', () => {
+    const state = makeGameState({ phase: 'bidding' });
+    const result = validatePlay(state, 'p1', heartA, [heartA]);
+    expect(result.valid).toBe(false);
+    expect(result.errorMessage).toMatch(/playing phase/i);
+  });
+
+  it('rejects when not player turn', () => {
+    const state = makeGameState({ currentPlayerPosition: 1 });
+    const result = validatePlay(state, 'p1', heartA, [heartA]);
+    expect(result.valid).toBe(false);
+    expect(result.errorMessage).toMatch(/not your turn/i);
+  });
+
+  it('rejects when card not in hand', () => {
+    const state = makeGameState();
+    const result = validatePlay(state, 'p1', heartA, [heartK]);
+    expect(result.valid).toBe(false);
+    expect(result.errorMessage).toMatch(/not in hand/i);
+  });
+
+  it('allows valid non-spade lead', () => {
+    const state = makeGameState();
+    const result = validatePlay(state, 'p1', heartA, [heartA, spadeA]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects spade lead when not broken and player has non-spades', () => {
+    const state = makeGameState();
+    const result = validatePlay(state, 'p1', spadeA, [spadeA, heartA]);
+    expect(result.valid).toBe(false);
+    expect(result.errorMessage).toMatch(/spades/i);
+  });
+
+  it('allows spade lead when broken', () => {
+    const state = makeGameState({
+      currentRound: {
+        currentTrick: { plays: [], leadSuit: null },
+        spadesBroken: true,
+      },
+    });
+    const result = validatePlay(state, 'p1', spadeA, [spadeA, heartA]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('allows spade lead when player only has spades', () => {
+    const state = makeGameState();
+    const result = validatePlay(state, 'p1', spadeA, [spadeA, spadeK]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('requires following lead suit', () => {
+    const state = makeGameState({
+      currentRound: {
+        currentTrick: {
+          plays: [{ playerId: 'p1', card: heartA }],
+          leadSuit: 'hearts',
+        },
+        spadesBroken: false,
+      },
+      currentPlayerPosition: 1,
+    });
+    const result = validatePlay(state, 'p2', clubA, [clubA, heartK]);
+    expect(result.valid).toBe(false);
+    expect(result.errorMessage).toMatch(/follow suit/i);
+  });
+
+  it('allows any card when player lacks lead suit', () => {
+    const state = makeGameState({
+      currentRound: {
+        currentTrick: {
+          plays: [{ playerId: 'p1', card: heartA }],
+          leadSuit: 'hearts',
+        },
+        spadesBroken: false,
+      },
+      currentPlayerPosition: 1,
+    });
+    const result = validatePlay(state, 'p2', spadeA, [spadeA, clubA]);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('getPlayableCards', () => {
+  it('returns only non-spade cards when leading with spades unbroken', () => {
+    const state = makeGameState();
+    const hand = [spadeA, spadeK, heartA, clubA, diamondA];
+    const playable = getPlayableCards(state, 'p1', hand);
+    expect(playable).toEqual([heartA, clubA, diamondA]);
+  });
+
+  it('returns only lead-suit cards when following and player has that suit', () => {
+    const state = makeGameState({
+      currentRound: {
+        currentTrick: {
+          plays: [{ playerId: 'p1', card: heartA }],
+          leadSuit: 'hearts',
+        },
+        spadesBroken: false,
+      },
+      currentPlayerPosition: 1,
+    });
+    const hand = [heart5, heartK, clubA, spade5];
+    const playable = getPlayableCards(state, 'p2', hand);
+    expect(playable).toEqual([heart5, heartK]);
+  });
+
+  it('returns all cards when player lacks lead suit', () => {
+    const state = makeGameState({
+      currentRound: {
+        currentTrick: {
+          plays: [{ playerId: 'p1', card: heartA }],
+          leadSuit: 'hearts',
+        },
+        spadesBroken: false,
+      },
+      currentPlayerPosition: 1,
+    });
+    const hand = [clubA, club5, spadeA, diamondA];
+    const playable = getPlayableCards(state, 'p2', hand);
+    expect(playable).toEqual([clubA, club5, spadeA, diamondA]);
+  });
+
+  it('returns all spades when leading with only spades in hand', () => {
+    const state = makeGameState();
+    const hand = [spadeA, spadeK, spade5];
+    const playable = getPlayableCards(state, 'p1', hand);
+    expect(playable).toEqual([spadeA, spadeK, spade5]);
+  });
+});

--- a/packages/shared/src/validation/play-validator.ts
+++ b/packages/shared/src/validation/play-validator.ts
@@ -1,7 +1,23 @@
 import type { Card } from '../types/card.js';
-import type { GameState } from '../types/game-state.js';
 import type { PlayerId } from '../types/player.js';
 import { hasSuit, hasOnlySpades } from '../game-logic/deck.js';
+
+/**
+ * Minimal game state interface for play validation.
+ * Both server-side GameState and ClientGameState satisfy this structurally.
+ */
+export interface PlayValidationGameState {
+  phase: string;
+  players: Array<{ id: PlayerId; position: number }>;
+  currentPlayerPosition: number;
+  currentRound: {
+    currentTrick: {
+      plays: Array<{ playerId: PlayerId; card: Card }>;
+      leadSuit: Card['suit'] | null;
+    };
+    spadesBroken: boolean;
+  } | null;
+}
 
 export interface PlayValidationResult {
   valid: boolean;
@@ -9,7 +25,7 @@ export interface PlayValidationResult {
 }
 
 export function validatePlay(
-  gameState: GameState,
+  gameState: PlayValidationGameState,
   playerId: PlayerId,
   card: Card,
   playerHand: Card[]
@@ -61,7 +77,7 @@ export function validatePlay(
 }
 
 export function getPlayableCards(
-  gameState: GameState,
+  gameState: PlayValidationGameState,
   playerId: PlayerId,
   playerHand: Card[]
 ): Card[] {


### PR DESCRIPTION
## Summary
- Generalize `validatePlay`/`getPlayableCards` to accept a `PlayValidationGameState` interface so both server `GameState` and `ClientGameState` can use the same validation logic
- Compute playable cards in `GameTable` via `useMemo` and pass to `PlayerHand` for per-card disabled state — players now see which cards are legal plays
- Clear stale card selection via `useEffect` when playable cards change (e.g., after state update)
- Add 13 unit tests for `validatePlay` and `getPlayableCards` covering all validation rules
- Add 2 E2E tests verifying spade-leading restrictions and follow-suit restrictions are reflected in the UI
- Improve `playFirstCard` E2E helper to wait for server-confirmed card removal, preventing stale-page race conditions

## Test plan
- [x] Unit tests: 13 new tests in `play-validator.test.ts` (all pass)
- [x] E2E tests: 2 new tests in `card-playing.spec.ts` (all pass)
- [x] Full E2E suite: 20 passed, 2 skipped (pre-existing)
- [x] Shared package build: clean
- [x] Client build: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)