### PR TITLE
feat: serve built client from Express server for single-port deployment

### DIFF
--- a/apps/client/src/socket/socket-context.tsx
+++ b/apps/client/src/socket/socket-context.tsx
@@ -19,8 +19,10 @@ export function SocketProvider({ children }: { children: React.ReactNode }) {
   const [connected, setConnected] = useState(false);
 
   useEffect(() => {
+    const serverUrl = import.meta.env.VITE_SERVER_URL
+      || (import.meta.env.DEV ? 'http://localhost:3001' : undefined);
     const newSocket: TypedSocket = io(
-      import.meta.env.VITE_SERVER_URL || 'http://localhost:3001',
+      serverUrl ?? window.location.origin,
       {
         autoConnect: true,
         reconnection: true,


### PR DESCRIPTION
## Summary
- Express server now serves the built client `dist/` files when they exist, enabling single-port production deployment
- Client Socket.io connection auto-detects same-origin in production builds (no hardcoded `localhost:3001`)
- Development flow is unchanged — Vite dev server on 5173 with proxy to server on 3001 still works as before

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes
- [ ] `pnpm dev` still works (Vite on 5173, server on 3001, socket proxy)
- [ ] After `pnpm build`, running just the server serves the client at `localhost:3001`

🤖 Generated with [Claude Code](https://claude.com/claude-code)