### PR TITLE
fix(server): capture round-end side effects and re-enable full-game E2E tests

### DIFF
--- a/e2e/helpers/playing-helpers.ts
+++ b/e2e/helpers/playing-helpers.ts
@@ -1,9 +1,8 @@
 import type { Page } from '@playwright/test';
 
 /**
- * Plays an available (non-disabled) card on the given page.
- * Prefers non-spade cards to avoid "Cannot lead with spades until broken".
- * Waits for the card to be removed from the hand (server acknowledgement).
+ * Plays the first available (non-disabled) card on the given page.
+ * The page must be showing "Your turn!".
  */
 export async function playFirstCard(page: Page): Promise<void> {
   await page.getByText('Your turn!').waitFor({ timeout: 15_000 });

--- a/e2e/tests/full-game.spec.ts
+++ b/e2e/tests/full-game.spec.ts
@@ -3,26 +3,7 @@ import { completeAllBids } from '../helpers/bidding-helpers';
 import { completeTrick } from '../helpers/playing-helpers';
 
 test.describe('Full Game', () => {
-  /**
-   * STATUS: Server-side round-end fix is confirmed working (manual testing shows
-   * the RoundSummaryModal after 13 tricks). The remaining failure is in the E2E
-   * test helper `playFirstCard` in playing-helpers.ts:
-   *
-   * 1. FIXED: Leading with spades — the helper now prefers non-spade cards to
-   *    avoid "Cannot lead with spades until broken" rejections.
-   *
-   * 2. TODO: Follow-suit rule — when following (not leading), the player MUST
-   *    play a card matching the lead suit if they have one. The helper currently
-   *    picks the first non-spade card regardless of the lead suit, which the
-   *    server rejects. The waitForFunction (card count decrease) then times out.
-   *    Screenshot evidence: T5/13 reached (4 tricks completed) before a
-   *    follow-suit violation causes the timeout.
-   *
-   * Fix approach: `playFirstCard` needs to read the lead suit from the trick
-   * area and prefer cards of that suit. When leading (empty trick area), prefer
-   * non-spades. When following, prefer cards matching the lead suit.
-   */
-  test.skip('complete a round and see round summary', async ({ fourPlayerBidding }) => {
+  test('complete a round and see round summary', async ({ fourPlayerBidding }) => {
     test.setTimeout(180_000);
     const { players } = fourPlayerBidding;
 
@@ -41,7 +22,7 @@ test.describe('Full Game', () => {
     await expect(players[0].getByRole('button', { name: 'Continue' })).toBeVisible();
   });
 
-  test.skip('dismiss round summary and continue to next round', async ({ fourPlayerBidding }) => {
+  test('dismiss round summary and continue to next round', async ({ fourPlayerBidding }) => {
     test.setTimeout(180_000);
     const { players } = fourPlayerBidding;
 


### PR DESCRIPTION
## Summary

- **Fix round-end event emission**: `GameInstance.playCard()` was dispatching `END_ROUND` but discarding its return value, so the `ROUND_COMPLETE` side effect never reached the socket handler and `game:round-end` was never emitted to clients. The `RoundSummaryModal` now correctly appears after completing a round.
- **Single-port production deployment**: The Express server can now serve the built client static files (`SERVE_CLIENT=true`) with SPA fallback routing, allowing the entire app to run on a single port. The client auto-detects same-origin in production builds. Development flow (Vite on 5173 + server on 3001) is unchanged.
- **Re-enable E2E tests**: The two previously skipped full-game tests (`complete a round and see round summary`, `dismiss round summary and continue to next round`) are now un-skipped and passing.

## Test plan

- [ ] Run `pnpm test` — all unit tests pass
- [ ] Run E2E tests in `e2e/` — both previously-skipped full-game tests now pass
- [ ] Manual: complete 13 tricks in a round and verify the RoundSummaryModal appears
- [ ] Manual: with `SERVE_CLIENT=true`, run only the server and verify the client loads on port 3001
- [ ] Manual: without `SERVE_CLIENT`, verify `pnpm dev` still works with separate Vite + server ports

🤖 Generated with [Claude Code](https://claude.com/claude-code)