### PR TITLE
chore: add .claudeignore to optimize Claude Code context

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,44 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Build outputs
+dist/
+build/
+.next/
+out/
+
+# Testing
+coverage/
+.nyc_output/
+playwright-report/
+test-results/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE/Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Misc
+.cache/
+.parcel-cache/
+.turbo/


### PR DESCRIPTION
## Summary
- Add `.claudeignore` file to exclude build artifacts, dependencies, and generated files from Claude Code's context

## Benefits
- Improves Claude Code performance by reducing context size
- Reduces noise when working with the codebase
- Excludes common patterns: node_modules, dist, build outputs, test results, logs, IDE files

🤖 Generated with [Claude Code](https://claude.com/claude-code)