### PR TITLE
fix(client): only visually disable cards when it is the player's turn

### DIFF
--- a/apps/client/src/components/game/GameTable.tsx
+++ b/apps/client/src/components/game/GameTable.tsx
@@ -177,7 +177,6 @@ export function GameTable({
             onSelectCard={setSelectedCard}
             faceDown={isBidding && !cardsRevealed}
             playableCards={playableCards}
-            isBiddingPhase={isBidding && cardsRevealed}
           />
 
           {!isBidding && (

--- a/apps/client/src/components/game/PlayerHand.tsx
+++ b/apps/client/src/components/game/PlayerHand.tsx
@@ -10,7 +10,6 @@ interface PlayerHandProps {
   onSelectCard: (card: CardType | null) => void;
   faceDown?: boolean;
   playableCards?: CardType[];
-  isBiddingPhase?: boolean;
 }
 
 export function PlayerHand({
@@ -21,7 +20,6 @@ export function PlayerHand({
   onSelectCard,
   faceDown = false,
   playableCards,
-  isBiddingPhase = false,
 }: PlayerHandProps) {
   const isCardPlayable = (card: CardType): boolean => {
     if (!isMyTurn) return false;
@@ -84,9 +82,7 @@ export function PlayerHand({
                 disabled={!isCardPlayable(card)}
                 selected={isSelected}
                 testId="hand-card"
-                visuallyDisabled={
-                  isBiddingPhase ? false : !isCardPlayable(card)
-                }
+                visuallyDisabled={isMyTurn && !isCardPlayable(card)}
               />
             )}
           </div>


### PR DESCRIPTION
## Summary
- Cards now display in full color at all times except when it is the current player's turn to play and a card is restricted (e.g. spades not yet broken)
- Extends the bidding-phase fix from #19 to all non-active game states: waiting for other players, bidding, trick-end, etc.
- Removes the now-unnecessary `isBiddingPhase` prop from `PlayerHand`

## Implementation Details
Replaced `isBiddingPhase ? false : !isCardPlayable(card)` with `isMyTurn && !isCardPlayable(card)`.

Since `isMyTurn` in `PlayerHand` is already `isPlaying && isMyTurn` (passed from `GameTable`), this single expression naturally covers every phase:
- **Playing, my turn**: restricted cards are visually disabled; playable cards are full color ✓
- **Playing, waiting for others**: all cards full color ✓
- **Bidding**: all cards full color ✓

## Test plan
- [x] Manual: Cards appear in full color while waiting for another player to play
- [x] Manual: Cards appear in full color during bidding (unchanged from #19)
- [x] Manual: Restricted cards (e.g. spades before broken) are still grayed out when it is my turn
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)