### PR TITLE
feat(bidding): show blind nil/see cards dialog to all waiting players

### DIFF
--- a/apps/client/src/components/bidding/BiddingPanel.tsx
+++ b/apps/client/src/components/bidding/BiddingPanel.tsx
@@ -87,90 +87,152 @@ export function BiddingPanel({
         boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
       }}
     >
-      {isMyTurn && !hasBid ? (
-        !cardsRevealed ? (
-          <div
-            style={{ display: 'flex', gap: '12px', justifyContent: 'center' }}
-          >
-            <Button variant="secondary" onClick={handleBlindNilBid}>
+      {hasBid ? (
+        <div
+          style={{
+            textAlign: 'center',
+            color: '#6b7280',
+            padding: '20px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '8px',
+          }}
+        >
+          <div>
+            Your bid:{' '}
+            <strong>
+              {myBid?.isBlindNil
+                ? 'Blind Nil'
+                : myBid?.isNil
+                  ? 'Nil'
+                  : myBid?.bid}
+            </strong>
+          </div>
+          {gameState.currentPlayerPosition != null && (
+            <div style={{ fontSize: '14px' }}>
+              Waiting for{' '}
+              {
+                gameState.players.find(
+                  (p) => p.position === gameState.currentPlayerPosition
+                )?.nickname
+              }{' '}
+              to bid...
+            </div>
+          )}
+        </div>
+      ) : !cardsRevealed ? (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '12px',
+            alignItems: 'center',
+          }}
+        >
+          <div style={{ display: 'flex', gap: '12px' }}>
+            <Button
+              variant="secondary"
+              onClick={handleBlindNilBid}
+              disabled={!isMyTurn}
+            >
               Bid Blind Nil
             </Button>
             <Button onClick={handleSeeCards}>See Cards</Button>
           </div>
-        ) : (
-          <>
-            <div style={{ marginBottom: '16px' }}>
-              <div
-                style={{
-                  fontSize: '14px',
-                  color: '#6b7280',
-                  marginBottom: '8px',
-                }}
-              >
-                Select your bid:
-              </div>
-              <div
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: 'repeat(7, 1fr)',
-                  gap: '8px',
-                }}
-              >
-                {Array.from({ length: 13 }, (_, i) => i + 1).map((bid) => {
-                  const isDisabled =
-                    bid > maxAllowedBid ||
-                    (gameState.disabledBids?.includes(bid) ?? false);
-                  return (
-                    <button
-                      key={bid}
-                      onClick={() => !isDisabled && setSelectedBid(bid)}
-                      disabled={isDisabled}
-                      style={{
-                        padding: '12px',
-                        fontSize: '16px',
-                        fontWeight: 600,
-                        backgroundColor:
-                          selectedBid === bid ? '#3b82f6' : '#f3f4f6',
-                        color: selectedBid === bid ? '#fff' : '#374151',
-                        border: 'none',
-                        borderRadius: '8px',
-                        cursor: isDisabled ? 'not-allowed' : 'pointer',
-                        opacity: isDisabled ? 0.4 : 1,
-                      }}
-                    >
-                      {bid}
-                    </button>
-                  );
-                })}
-              </div>
+          <div
+            style={{
+              fontSize: '14px',
+              color: isMyTurn ? '#3b82f6' : '#6b7280',
+            }}
+          >
+            {isMyTurn ? (
+              "It's your turn to bid!"
+            ) : (
+              <>
+                Waiting for{' '}
+                {
+                  gameState.players.find(
+                    (p) => p.position === gameState.currentPlayerPosition
+                  )?.nickname
+                }{' '}
+                to bid...
+              </>
+            )}
+          </div>
+        </div>
+      ) : isMyTurn ? (
+        <>
+          <div style={{ marginBottom: '16px' }}>
+            <div
+              style={{
+                fontSize: '14px',
+                color: '#6b7280',
+                marginBottom: '8px',
+              }}
+            >
+              Select your bid:
             </div>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(7, 1fr)',
+                gap: '8px',
+              }}
+            >
+              {Array.from({ length: 13 }, (_, i) => i + 1).map((bid) => {
+                const isDisabled =
+                  bid > maxAllowedBid ||
+                  (gameState.disabledBids?.includes(bid) ?? false);
+                return (
+                  <button
+                    key={bid}
+                    onClick={() => !isDisabled && setSelectedBid(bid)}
+                    disabled={isDisabled}
+                    style={{
+                      padding: '12px',
+                      fontSize: '16px',
+                      fontWeight: 600,
+                      backgroundColor:
+                        selectedBid === bid ? '#3b82f6' : '#f3f4f6',
+                      color: selectedBid === bid ? '#fff' : '#374151',
+                      border: 'none',
+                      borderRadius: '8px',
+                      cursor: isDisabled ? 'not-allowed' : 'pointer',
+                      opacity: isDisabled ? 0.4 : 1,
+                    }}
+                  >
+                    {bid}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
 
-            <div style={{ display: 'flex', gap: '12px' }}>
-              <button
-                onClick={handleNilBid}
-                style={{
-                  padding: '12px 24px',
-                  fontSize: '16px',
-                  fontWeight: 600,
-                  backgroundColor: selectedBid === 0 ? '#3b82f6' : '#f3f4f6',
-                  color: selectedBid === 0 ? '#fff' : '#374151',
-                  border: 'none',
-                  borderRadius: '8px',
-                  cursor: 'pointer',
-                }}
-              >
-                Nil
-              </button>
-              <Button
-                onClick={handleSubmitBid}
-                disabled={selectedBid === null}
-                style={{ flex: 1 }}
-              >
-                Submit Bid
-              </Button>
-            </div>
-          </>
-        )
+          <div style={{ display: 'flex', gap: '12px' }}>
+            <button
+              onClick={handleNilBid}
+              style={{
+                padding: '12px 24px',
+                fontSize: '16px',
+                fontWeight: 600,
+                backgroundColor: selectedBid === 0 ? '#3b82f6' : '#f3f4f6',
+                color: selectedBid === 0 ? '#fff' : '#374151',
+                border: 'none',
+                borderRadius: '8px',
+                cursor: 'pointer',
+              }}
+            >
+              Nil
+            </button>
+            <Button
+              onClick={handleSubmitBid}
+              disabled={selectedBid === null}
+              style={{ flex: 1 }}
+            >
+              Submit Bid
+            </Button>
+          </div>
+        </>
       ) : (
         <div
           style={{
@@ -179,28 +241,13 @@ export function BiddingPanel({
             padding: '20px',
           }}
         >
-          {hasBid ? (
-            <>
-              Your bid:{' '}
-              <strong>
-                {myBid?.isBlindNil
-                  ? 'Blind Nil'
-                  : myBid?.isNil
-                    ? 'Nil'
-                    : myBid?.bid}
-              </strong>
-            </>
-          ) : (
-            <>
-              Waiting for{' '}
-              {
-                gameState.players.find(
-                  (p) => p.position === gameState.currentPlayerPosition
-                )?.nickname
-              }{' '}
-              to bid...
-            </>
-          )}
+          Waiting for{' '}
+          {
+            gameState.players.find(
+              (p) => p.position === gameState.currentPlayerPosition
+            )?.nickname
+          }{' '}
+          to bid...
         </div>
       )}
     </div>

--- a/e2e/helpers/bidding-helpers.ts
+++ b/e2e/helpers/bidding-helpers.ts
@@ -55,19 +55,12 @@ export async function completeAllBids(
  * Finds which page currently has bidding controls visible.
  */
 async function findCurrentBidder(pages: Page[]): Promise<Page> {
-  // Poll until one page shows bidding controls
+  // Poll until one page shows "It's your turn to bid!" (only shown for the active bidder, pre-reveal)
   for (let attempt = 0; attempt < 30; attempt++) {
     for (const page of pages) {
-      // Check for "See Cards" button (pre-reveal) or "Submit Bid" button (post-reveal)
-      const seeCards = page.getByRole('button', { name: 'See Cards' });
-      const bidNil = page.getByRole('button', { name: 'Nil' });
-      const blindNil = page.getByRole('button', { name: 'Bid Blind Nil' });
+      const yourTurn = page.getByText("It's your turn to bid!");
 
-      if (
-        (await seeCards.isVisible({ timeout: 100 }).catch(() => false)) ||
-        (await bidNil.isVisible({ timeout: 100 }).catch(() => false)) ||
-        (await blindNil.isVisible({ timeout: 100 }).catch(() => false))
-      ) {
+      if (await yourTurn.isVisible({ timeout: 100 }).catch(() => false)) {
         return page;
       }
     }


### PR DESCRIPTION
## Summary

- Players waiting for others to bid now see the **Bid Blind Nil / See Cards** dialog instead of a plain waiting message
- **Bid Blind Nil** is disabled until it is actually the player's turn
- **See Cards** is always clickable; doing so reveals the hand and transitions to a "Waiting for X to bid..." message
- A status line below the buttons reads **"It's your turn to bid!"** (blue) when active, or **"Waiting for X to bid..."** (gray) otherwise
- The **"Your bid: X"** confirmation panel also shows "Waiting for X to bid..." while others are still bidding

## Test plan

- [x] All 42 E2E tests pass
- [x] Updated `findCurrentBidder` helper to detect active bidder via `"It's your turn to bid!"` text (buttons now appear for all players, so button visibility is no longer a reliable signal)
- [x] Removed `"Submit Bid"` as a secondary detection signal — it caused a race condition where the previous bidder could be returned again before the server confirmed their bid
- [x] Fixed stale assertion `'My Bid: Blind Nil'` → `/Your bid:.*Blind Nil/`
- [x] Manual testing confirms desired UX behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)