### PR TITLE
fix(client): display 'BNL' for opponent blind nil bids

### DIFF
--- a/apps/client/src/components/game/OpponentArea.tsx
+++ b/apps/client/src/components/game/OpponentArea.tsx
@@ -65,7 +65,8 @@ export function OpponentArea({
         </div>
         {bid && (
           <div style={{ fontSize: '12px', marginTop: '4px' }}>
-            Bid: {bid.isNil ? 'Nil' : bid.bid} | Won: {tricksWon}
+            Bid: {bid.isBlindNil ? 'BNL' : bid.isNil ? 'Nil' : bid.bid} | Won:{' '}
+            {tricksWon}
           </div>
         )}
         {!player.connected && (


### PR DESCRIPTION
## Summary
- Opponent blind nil bids were displaying as `0` instead of a meaningful label
- Fixed by checking `isBlindNil` before `isNil` in `OpponentArea.tsx`
- Blind nil bids now display as `BNL`, regular nil bids display as `Nil`

## Test plan
- [ ] Start a game and have an opponent place a blind nil bid
- [ ] Verify the opponent's bid shows `BNL` (not `0`)
- [ ] Verify regular nil bids still show `Nil`
- [ ] Verify numeric bids are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)