### PR TITLE
fix(e2e): export Page type from game-fixtures

### DIFF
--- a/e2e/fixtures/game-fixtures.ts
+++ b/e2e/fixtures/game-fixtures.ts
@@ -123,4 +123,4 @@ export const test = base.extend<GameFixtures>({
   },
 });
 
-export { expect } from '@playwright/test';
+export { expect, type Page } from '@playwright/test';


### PR DESCRIPTION
## Summary
- Re-exports the `Page` type from `@playwright/test` via `game-fixtures.ts` so test files can import it from the fixtures module without a TypeScript error
- Fixes: `Module '"../fixtures/game-fixtures"' declares 'Page' locally, but it is not exported.`

## Test plan
- [x] All 42 E2E tests pass locally
- [x] All unit tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)