### PR TITLE
feat(ci): enable Dependabot version update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  # JavaScript/TypeScript dependencies (pnpm workspace)
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 10
+    groups:
+      # These packages are always released together at the same version
+      typescript-eslint:
+        patterns:
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
+      # Vite, its React plugin, and Vitest are tightly coupled across major versions
+      vite-ecosystem:
+        patterns:
+          - 'vite'
+          - '@vitejs/*'
+          - 'vitest'
+          - '@vitest/*'
+      # ESLint core and its official packages
+      eslint-ecosystem:
+        patterns:
+          - 'eslint'
+          - '@eslint/*'
+          - 'eslint-config-*'
+          - 'eslint-plugin-*'
+
+  # GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to enable weekly version update PRs for npm dependencies and GitHub Actions
- Groups are defined for packages that must be updated in sync:
  - **`typescript-eslint`**: `typescript-eslint` + `@typescript-eslint/*` are always released at the same version
  - **`vite-ecosystem`**: `vite`, `@vitejs/*`, `vitest`, `@vitest/*` are tightly coupled across major versions (learned during security remediation — Vitest 2→3 was required because Vitest 2 internally re-installs Vite 5)
  - **`eslint-ecosystem`**: `eslint`, `@eslint/*`, `eslint-config-*`, `eslint-plugin-*` together (ESLint major upgrades require coordinated plugin updates)
- Also covers GitHub Actions (`actions/checkout`, `actions/setup-node`, `pnpm/action-setup`, etc.)
- `open-pull-requests-limit: 10` to accommodate the monorepo's dependency breadth

## Test plan

- [ ] Merge and confirm Dependabot begins generating version update PRs on the next Monday schedule (or trigger manually via GitHub's "Check for updates" button on the Dependabot settings page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)