### PR TITLE
fix(ci): restrict GITHUB_TOKEN to contents:read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Adds a top-level `permissions: contents: read` block to `ci.yml`
- All three CI jobs (lint-and-typecheck, unit-tests, e2e-tests) only need read access to checkout code, so a single workflow-level block is sufficient
- Resolves CodeQL code scanning alerts [#5](https://github.com/riendeau/spades-game/security/code-scanning/5), [#6](https://github.com/riendeau/spades-game/security/code-scanning/6), and [#7](https://github.com/riendeau/spades-game/security/code-scanning/7) (`actions/missing-workflow-permissions` / CWE-275)

## Test plan

- [ ] CI passes on this PR (all three jobs succeed with restricted token)
- [ ] Verify code scanning alerts close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)