### PR TITLE
docs: update Node.js prerequisite to 24 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A real-time multiplayer Spades card game built with TypeScript, React, and Socke
 
 ## Prerequisites
 
-- Node.js >= 18
+- Node.js >= 24 (LTS)
 - [pnpm](https://pnpm.io/)
 
 ## Getting Started


### PR DESCRIPTION
## Summary
- README listed `Node.js >= 18` but the project was upgraded to Node 24 LTS in #68
- Updates the Prerequisites section to reflect the actual requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)