### PR TITLE
fix: prevent player hand area from collapsing when hand is empty

### DIFF
--- a/apps/client/src/components/game/PlayerHand.tsx
+++ b/apps/client/src/components/game/PlayerHand.tsx
@@ -60,6 +60,7 @@ export function PlayerHand({
         justifyContent: 'center',
         gap: '-20px',
         padding: compact ? '8px' : '20px',
+        minHeight: compact ? '91px' : '140px',
       }}
     >
       {cards.map((card, idx) => {


### PR DESCRIPTION
## Summary
- Adds `minHeight` to the `PlayerHand` flex container so the hand area retains its height after the last card is played
- Desktop: `140px` (100px card + 20px top/bottom padding); Mobile: `91px` (75px card + 8px top/bottom padding)
- Prevents the UI layout shift that occurred at round end when a player's hand became empty

## Test plan
- [ ] Play a full round and confirm the hand area does not collapse after the last card is played
- [ ] Verify layout looks correct on both desktop and mobile