### PR TITLE
fix: cap trick counter at 13 to prevent T14/13 display

### DIFF
--- a/apps/client/src/components/game/ScoreBoard.tsx
+++ b/apps/client/src/components/game/ScoreBoard.tsx
@@ -14,10 +14,13 @@ export function ScoreBoard({ gameState, compact = false }: ScoreBoardProps) {
     <>
       R{gameState.currentRound.roundNumber} · T
       {gameState.currentRound.tricksWon
-        ? Object.values(gameState.currentRound.tricksWon).reduce(
-            (a, b) => a + b,
-            0
-          ) + 1
+        ? Math.min(
+            Object.values(gameState.currentRound.tricksWon).reduce(
+              (a, b) => a + b,
+              0
+            ) + 1,
+            13
+          )
         : 1}
       /13
       {gameState.currentRound.spadesBroken && ' · ♠'}


### PR DESCRIPTION
## Summary
- After all 13 tricks are collected (round-end phase), `tricksWon` sums to 13 and the `+1` offset caused the scoreboard to briefly show "T14/13" before the round summary modal appeared
- Wraps the trick counter with `Math.min(..., 13)` so it caps at "T13/13"

## Test plan
- [x] All 140 unit tests pass
- [ ] Play a full round and verify the trick counter shows "T13/13" (not "T14/13") at round end

Partial: #78 (item 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)