### PR TITLE
feat(ui): increase desktop card and badge sizes

### DIFF
--- a/apps/client/src/components/game/GameTable.tsx
+++ b/apps/client/src/components/game/GameTable.tsx
@@ -209,7 +209,7 @@ export function GameTable({
                 flexDirection: 'column',
                 alignItems: 'center',
                 gap: '2px',
-                padding: isMobile ? '6px' : '12px',
+                padding: isMobile ? '6px' : '16px',
                 borderRadius: '10px',
                 backgroundColor: `rgba(${TEAM_RGB[myPlayer.team]}, ${isMyTurn ? 0.2 : 0.07})`,
                 border: isMyTurn
@@ -225,7 +225,7 @@ export function GameTable({
               <span
                 style={{
                   fontWeight: 600,
-                  fontSize: isMobile ? '12px' : '14px',
+                  fontSize: isMobile ? '12px' : '18px',
                   color: '#f9fafb',
                 }}
               >
@@ -233,7 +233,7 @@ export function GameTable({
               </span>
               <span
                 style={{
-                  fontSize: isMobile ? '10px' : '12px',
+                  fontSize: isMobile ? '10px' : '14px',
                   color: '#d1d5db',
                 }}
               >

--- a/apps/client/src/components/game/OpponentArea.tsx
+++ b/apps/client/src/components/game/OpponentArea.tsx
@@ -39,8 +39,8 @@ export function OpponentArea({
     display: 'flex',
     flexDirection: relativePosition === 'top' ? 'column' : 'row',
     alignItems: 'center',
-    gap: compact ? (isSideOpponent ? '4px' : '6px') : '12px',
-    padding: compact ? (isSideOpponent ? '4px 2px' : '6px') : '12px',
+    gap: compact ? (isSideOpponent ? '4px' : '6px') : '16px',
+    padding: compact ? (isSideOpponent ? '4px 2px' : '6px') : '16px',
     backgroundColor: `rgba(${TEAM_RGB[player.team]}, ${isCurrentPlayer ? 0.2 : 0.07})`,
     borderRadius: '12px',
     border: isCurrentPlayer
@@ -57,13 +57,13 @@ export function OpponentArea({
       <div
         style={{
           textAlign: 'center',
-          minWidth: compact && isSideOpponent ? '48px' : '80px',
+          minWidth: compact && isSideOpponent ? '48px' : '110px',
         }}
       >
         <div
           style={{
             fontWeight: 600,
-            fontSize: compact ? (isSideOpponent ? '11px' : '12px') : '14px',
+            fontSize: compact ? (isSideOpponent ? '11px' : '12px') : '18px',
             color: player.connected ? '#f9fafb' : '#9ca3af',
           }}
         >
@@ -71,7 +71,7 @@ export function OpponentArea({
         </div>
         <div
           style={{
-            fontSize: compact ? '10px' : '12px',
+            fontSize: compact ? '10px' : '14px',
             marginTop: '2px',
             color: '#d1d5db',
           }}

--- a/apps/client/src/components/game/PlayerHand.tsx
+++ b/apps/client/src/components/game/PlayerHand.tsx
@@ -60,7 +60,7 @@ export function PlayerHand({
         justifyContent: 'center',
         gap: '-20px',
         padding: compact ? '8px' : '20px',
-        minHeight: compact ? '91px' : '140px',
+        minHeight: compact ? '91px' : '170px',
       }}
     >
       {cards.map((card, idx) => {

--- a/apps/client/src/components/game/TrickArea.tsx
+++ b/apps/client/src/components/game/TrickArea.tsx
@@ -16,9 +16,9 @@ export function TrickArea({
   const trick = gameState.currentRound?.currentTrick;
   if (!trick) return null;
 
-  const width = compact ? 180 : 250;
-  const height = compact ? 150 : 200;
-  const offset = compact ? 8 : 10;
+  const width = compact ? 180 : 320;
+  const height = compact ? 150 : 280;
+  const offset = compact ? 8 : 15;
 
   // Calculate relative positions (rotate so my position is at bottom)
   const getRelativePosition = (pos: Position): Position => {
@@ -59,7 +59,7 @@ export function TrickArea({
               ...getPositionStyle(relPos),
             }}
           >
-            <Card card={play.card} small testId="trick-card" />
+            <Card card={play.card} small={compact} testId="trick-card" />
           </div>
         );
       })}

--- a/apps/client/src/components/ui/Card.tsx
+++ b/apps/client/src/components/ui/Card.tsx
@@ -49,8 +49,8 @@ export function Card({
       disabled={disabled}
       data-testid={testId}
       style={{
-        width: small ? '50px' : '70px',
-        height: small ? '75px' : '100px',
+        width: small ? '50px' : '90px',
+        height: small ? '75px' : '130px',
         backgroundColor: showDisabled ? '#e8e8e8' : '#fff',
         border: selected ? '3px solid #3b82f6' : '1px solid #ccc',
         borderRadius: '8px',
@@ -59,7 +59,7 @@ export function Card({
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        fontSize: small ? '14px' : '18px',
+        fontSize: small ? '14px' : '22px',
         fontWeight: 'bold',
         color,
         boxShadow: selected
@@ -73,7 +73,7 @@ export function Card({
       }}
     >
       <span>{card.rank}</span>
-      <span style={{ fontSize: small ? '20px' : '28px' }}>{symbol}</span>
+      <span style={{ fontSize: small ? '20px' : '36px' }}>{symbol}</span>
     </button>
   );
 }
@@ -82,8 +82,8 @@ export function CardBack({ small }: { small?: boolean }) {
   return (
     <div
       style={{
-        width: small ? '50px' : '70px',
-        height: small ? '75px' : '100px',
+        width: small ? '50px' : '90px',
+        height: small ? '75px' : '130px',
         backgroundColor: '#1e40af',
         border: '1px solid #1e3a8a',
         borderRadius: '8px',
@@ -94,7 +94,7 @@ export function CardBack({ small }: { small?: boolean }) {
           'repeating-linear-gradient(45deg, transparent, transparent 5px, rgba(255,255,255,0.1) 5px, rgba(255,255,255,0.1) 10px)',
       }}
     >
-      <span style={{ color: '#fff', fontSize: small ? '20px' : '28px' }}>
+      <span style={{ color: '#fff', fontSize: small ? '20px' : '36px' }}>
         {'\u2660'}
       </span>
     </div>


### PR DESCRIPTION
## Summary

- Cards (hand + trick area): `70×100` → `90×130px`; rank font `18→22px`, suit symbol `28→36px`
- Trick area cards: promoted from always-`small` to full-size on desktop (`small={compact}`); container expanded from `250×200` → `320×280px`
- Player badges (all 4 positions): name font `14→18px`, bid/won font `12→14px`, padding `12→16px`, min-width `80→110px`
- `PlayerHand` desktop `minHeight` updated to `170px` to match taller cards

Mobile layout is completely unchanged — all size decisions gate on `isMobile`/`compact`.

## Test plan

- [ ] Start a desktop game and verify cards in hand are noticeably larger and readable
- [ ] Play a card into the trick area and verify trick cards are full-size (not tiny)
- [ ] Check all four player badges show larger name/bid text with more padding
- [ ] Verify mobile layout is unaffected (narrow viewport or devtools mobile emulation)
- [ ] Run unit tests: `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)