### PR TITLE
fix(auth): preserve original URL through OAuth login flow

### DIFF
--- a/apps/client/src/components/auth/LoginGate.tsx
+++ b/apps/client/src/components/auth/LoginGate.tsx
@@ -111,7 +111,7 @@ export function LoginGate({ children }: LoginGateProps) {
           )}
 
           <a
-            href="/auth/google"
+            href={`/auth/google${window.location.pathname !== '/' ? `?returnTo=${encodeURIComponent(window.location.pathname)}` : ''}`}
             style={{
               display: 'flex',
               alignItems: 'center',


### PR DESCRIPTION
## Summary
- When visiting a share link (e.g., `/room/ABC123`) while unauthenticated, users were redirected to `/` after Google login instead of back to the room
- `LoginGate` now passes the current path as a `returnTo` query param to `/auth/google`
- Server stores `returnTo` in the session before the OAuth redirect and uses it after successful authentication
- Validates `returnTo` is a relative path (starts with `/`, not `//`) to prevent open redirects

## Test plan
- [ ] Visit `/room/ABCDEF` while logged out → complete Google login → verify redirect to `/room/ABCDEF`
- [ ] Visit `/` while logged out → complete Google login → verify redirect to `/`
- [ ] Verify `not_allowed` error flow still works (redirects to `/?error=not_allowed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)