### PR TITLE
fix(client): pass team names through to score progression chart

### DIFF
--- a/apps/client/src/components/game/GameTable.tsx
+++ b/apps/client/src/components/game/GameTable.tsx
@@ -401,6 +401,7 @@ export function GameTable({
           scoreHistory={scoreHistory}
           winningScore={gameState.winningScore}
           onClose={() => setShowScoreChart(false)}
+          teamNames={gameState.teamNames}
         />
       )}
     </div>

--- a/apps/client/src/components/game/ScoreChartModal.tsx
+++ b/apps/client/src/components/game/ScoreChartModal.tsx
@@ -7,12 +7,14 @@ interface ScoreChartModalProps {
   scoreHistory: ScoreHistoryEntry[];
   winningScore: number;
   onClose: () => void;
+  teamNames?: { team1: string; team2: string };
 }
 
 export function ScoreChartModal({
   scoreHistory,
   winningScore,
   onClose,
+  teamNames,
 }: ScoreChartModalProps) {
   return (
     <div
@@ -46,6 +48,7 @@ export function ScoreChartModal({
         <ScoreProgressionChart
           scoreHistory={scoreHistory}
           winningScore={winningScore}
+          teamNames={teamNames}
         />
 
         <div style={{ marginTop: '16px', textAlign: 'center' }}>

--- a/apps/client/src/components/game/__tests__/score-chart-modal.test.tsx
+++ b/apps/client/src/components/game/__tests__/score-chart-modal.test.tsx
@@ -1,0 +1,41 @@
+import type { ScoreHistoryEntry } from '@spades/shared';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { ScoreChartModal } from '../ScoreChartModal';
+
+const scoreHistory: ScoreHistoryEntry[] = [
+  { round: 0, team1Score: 0, team2Score: 0 },
+  { round: 1, team1Score: 52, team2Score: 38 },
+];
+
+describe('ScoreChartModal', () => {
+  it('passes teamNames through to ScoreProgressionChart', () => {
+    const html = renderToStaticMarkup(
+      <ScoreChartModal
+        scoreHistory={scoreHistory}
+        winningScore={500}
+        onClose={() => {}}
+        teamNames={{ team1: 'The Aces', team2: 'Wild Cards' }}
+      />
+    );
+
+    expect(html).toContain('The Aces');
+    expect(html).toContain('Wild Cards');
+    expect(html).not.toContain('Team 1');
+    expect(html).not.toContain('Team 2');
+  });
+
+  it('falls back to default names when teamNames is not provided', () => {
+    const html = renderToStaticMarkup(
+      <ScoreChartModal
+        scoreHistory={scoreHistory}
+        winningScore={500}
+        onClose={() => {}}
+      />
+    );
+
+    expect(html).toContain('Team 1');
+    expect(html).toContain('Team 2');
+  });
+});


### PR DESCRIPTION
## Summary
- `ScoreChartModal` was not forwarding `teamNames` to `ScoreProgressionChart`, so the chart legend always displayed "Team 1" / "Team 2" instead of the actual team names from game state
- Added `teamNames` prop to `ScoreChartModal` and wired it from `gameState.teamNames` in `GameTable`
- Added unit tests verifying team names render correctly and fallback defaults still work

## Test plan
- [x] Unit tests pass (`pnpm test` — 527 tests, all green)
- [ ] Manually open Score Progression chart during a game and verify actual team names appear in the legend

🤖 Generated with [Claude Code](https://claude.com/claude-code)