### PR TITLE
fix(server): scope rate limiter to API/auth routes only

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -42,15 +42,25 @@ const httpServer = createServer(app);
 // from X-Forwarded-Proto rather than defaulting to http://
 app.set('trust proxy', 1);
 
-// Rate limiting for API and auth routes only (not static assets or SPA fallback)
-const limiter = rateLimit({
+// Strict rate limiting for API and auth routes (DB queries, OAuth, AI calls)
+const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 300, // per IP across /api + /auth combined
   standardHeaders: true,
   legacyHeaders: false,
 });
-app.use('/api', limiter);
-app.use('/auth', limiter);
+app.use('/api', apiLimiter);
+app.use('/auth', apiLimiter);
+
+// Generous rate limiting for the SPA fallback (res.sendFile — filesystem I/O).
+// express.static is excluded: it runs before this and short-circuits matched files.
+// This satisfies CodeQL js/missing-rate-limiting without penalizing normal browsing.
+const pageLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 1000, // page navigations only — static assets don't count
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 // Health check — always public, before auth middleware
 app.get('/health', (_req, res) => {
@@ -303,7 +313,7 @@ if (servingClient) {
   app.use(BASE_PATH, express.static(clientDistPath));
 
   // SPA fallback: serve index.html for any non-API, non-file request under BASE_PATH
-  app.get(`${BASE_PATH}*path`, (_req, res) => {
+  app.get(`${BASE_PATH}*path`, pageLimiter, (_req, res) => {
     res.sendFile(path.join(clientDistPath, 'index.html'));
   });
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -42,14 +42,15 @@ const httpServer = createServer(app);
 // from X-Forwarded-Proto rather than defaulting to http://
 app.set('trust proxy', 1);
 
-// Rate limiting for all HTTP routes (Socket.io traffic is unaffected)
+// Rate limiting for API and auth routes only (not static assets or SPA fallback)
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 300, // generous limit for SPA + API calls per IP
+  max: 300, // per IP across /api + /auth combined
   standardHeaders: true,
   legacyHeaders: false,
 });
-app.use(limiter);
+app.use('/api', limiter);
+app.use('/auth', limiter);
 
 // Health check — always public, before auth middleware
 app.get('/health', (_req, res) => {


### PR DESCRIPTION
## Summary
- The `express-rate-limit` middleware was applied globally via `app.use(limiter)`, counting **all** HTTP requests (including static JS/CSS chunks and SPA fallback HTML) against the 300-request-per-15-minute limit
- With 4 players navigating between the lobby, game rooms, and stats page, static asset requests quickly exhausted the budget, producing a "Too many requests" error page
- Split into two separate rate limiters:
  - **`apiLimiter`** (300/15min): `/api` and `/auth` routes — DB queries, OAuth flows, AI calls
  - **`pageLimiter`** (1000/15min): SPA fallback route only — the `res.sendFile` that CodeQL alert #4 originally flagged
- `express.static` runs before the SPA fallback and short-circuits for matched files, so static assets (JS/CSS/images) hit neither limiter

Resolves the "Too many requests" error during normal browsing while keeping CodeQL `js/missing-rate-limiting` (alert #4) satisfied.

## Test plan
- [x] All 448 unit tests pass
- [x] All 36 E2E tests pass
- [ ] Deploy and verify navigating between pages no longer triggers "Too many requests"
- [ ] Verify CodeQL re-scan does not re-open alert #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)