### PR TITLE
fix(server): move auth rate limiter into router for CodeQL visibility

### DIFF
--- a/apps/server/src/auth/auth-routes.ts
+++ b/apps/server/src/auth/auth-routes.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import passport from 'passport';
 import type { User } from './passport-config.js';
 import { DEV_USER } from './passport-config.js';
@@ -12,6 +13,17 @@ declare module 'express-session' {
 }
 
 export const authRouter: express.Router = express.Router();
+
+// Rate limiting applied directly on the router so CodeQL can trace it
+// (the mount-point limiter in index.ts is not visible to static analysis)
+authRouter.use(
+  rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 300,
+    standardHeaders: true,
+    legacyHeaders: false,
+  })
+);
 
 const oauthConfigured = Boolean(
   process.env.GOOGLE_CLIENT_ID &&

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -42,15 +42,15 @@ const httpServer = createServer(app);
 // from X-Forwarded-Proto rather than defaulting to http://
 app.set('trust proxy', 1);
 
-// Strict rate limiting for API and auth routes (DB queries, OAuth, AI calls)
+// Strict rate limiting for API routes (DB queries, AI calls)
+// Auth routes have their own limiter inside auth-routes.ts.
 const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 300, // per IP across /api + /auth combined
+  max: 300, // per IP
   standardHeaders: true,
   legacyHeaders: false,
 });
 app.use('/api', apiLimiter);
-app.use('/auth', apiLimiter);
 
 // Generous rate limiting for the SPA fallback (res.sendFile — filesystem I/O).
 // express.static is excluded: it runs before this and short-circuits matched files.


### PR DESCRIPTION
## Summary
- CodeQL opened alerts https://github.com/riendeau/spades-game/security/code-scanning/9 and https://github.com/riendeau/spades-game/security/code-scanning/10 (`js/missing-rate-limiting`) on the `/google` and `/google/callback` handlers in `auth-routes.ts`
- The rate limiter was applied at the mount point in `index.ts` (`app.use('/auth', apiLimiter)`), but CodeQL does static per-file analysis and can't trace across files
- Moved the rate limiter into `authRouter.use()` inside `auth-routes.ts` so CodeQL can see it directly, and removed the now-redundant mount-point limiter from `index.ts`

## Test plan
- [x] All 448 unit tests pass
- [ ] Verify CodeQL re-scan closes alerts #9 and #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)