### PR TITLE
feat(client): pulse active player badge

### DIFF
--- a/apps/client/src/components/game/GameTable.tsx
+++ b/apps/client/src/components/game/GameTable.tsx
@@ -8,6 +8,7 @@ import type {
 import { getPlayableCards } from '@spades/shared';
 import React, { useState, useMemo, useEffect } from 'react';
 import { useIsMobile } from '../../hooks/use-is-mobile';
+import { badgePulseKeyframes } from '../../styles/animations';
 import { TEAM_COLORS, TEAM_RGB } from '../../styles/colors';
 import { AdUnit } from '../ads/AdUnit';
 import { BiddingPanel } from '../bidding/BiddingPanel';
@@ -325,8 +326,15 @@ export function GameTable({
                   : 'none',
                 transition:
                   'background-color 0.2s, border-color 0.2s, box-shadow 0.2s',
+                ...(isMyTurn
+                  ? {
+                      '--team-rgb': TEAM_RGB[myPlayer.team],
+                      animation: 'badge-pulse 1.8s ease-in-out infinite',
+                    }
+                  : {}),
               }}
             >
+              <style>{badgePulseKeyframes}</style>
               <span
                 style={{
                   fontWeight: 600,

--- a/apps/client/src/components/game/OpponentArea.tsx
+++ b/apps/client/src/components/game/OpponentArea.tsx
@@ -1,5 +1,6 @@
 import type { ClientGameState, PlayerId, Position } from '@spades/shared';
 import React, { useEffect, useState } from 'react';
+import { badgePulseKeyframes } from '../../styles/animations';
 import { TEAM_COLORS, TEAM_RGB } from '../../styles/colors';
 
 const IDLE_TIMEOUT_S = 120; // must match server IDLE_TIMEOUT_MS / 1000
@@ -86,6 +87,12 @@ export function OpponentArea({
       ? `0 0 12px rgba(${TEAM_RGB[player.team]}, 0.6)`
       : 'none',
     transition: 'background-color 0.2s, border-color 0.2s, box-shadow 0.2s',
+    ...(isCurrentPlayer
+      ? {
+          '--team-rgb': TEAM_RGB[player.team],
+          animation: 'badge-pulse 1.8s ease-in-out infinite',
+        }
+      : {}),
   };
 
   const formatCountdown = (seconds: number): string => {
@@ -97,6 +104,7 @@ export function OpponentArea({
 
   return (
     <div style={containerStyle}>
+      <style>{badgePulseKeyframes}</style>
       <div
         style={{
           textAlign: 'center',

--- a/apps/client/src/styles/animations.ts
+++ b/apps/client/src/styles/animations.ts
@@ -1,0 +1,12 @@
+export const badgePulseKeyframes = `
+@keyframes badge-pulse {
+  0%, 100% {
+    background-color: rgba(var(--team-rgb), 0.2);
+    box-shadow: 0 0 12px rgba(var(--team-rgb), 0.55);
+  }
+  50% {
+    background-color: rgba(var(--team-rgb), 0.38);
+    box-shadow: 0 0 22px rgba(var(--team-rgb), 0.95);
+  }
+}
+`;


### PR DESCRIPTION
## Summary
- Adds a subtle 1.8s ease-in-out infinite pulse to the current player's badge so the active turn is easier to spot at a glance.
- Applies to all four badges: the three opponent areas and the local (south) player badge.
- Team color is parameterized via a `--team-rgb` CSS custom property, so one shared `@keyframes` rule works for both teams.

## Details
- New file `apps/client/src/styles/animations.ts` exporting `badgePulseKeyframes`, which animates `background-color` (0.2 → 0.38 alpha) and `box-shadow` (12px/0.55 → 22px/0.95) between 0%/100% and 50%.
- `OpponentArea.tsx` and `GameTable.tsx` inject the keyframes via a `<style>` tag (matching the existing pattern in `TrickArea.tsx`) and set `animation: badge-pulse 1.8s ease-in-out infinite` plus `--team-rgb` only when the badge represents the current player.
- The border stays solid and the glow/tint pulse, which keeps player names readable. When the turn ends, the animation is removed and the existing 0.2s transition settles the badge back to its inactive state.

## Test plan
- [x] `pnpm test` (all 527 unit tests pass)
- [x] `pnpm --filter @spades/client build` (tsc + Vite build clean)
- [x] `pnpm lint` (0 errors; same pre-existing warnings as main)
- [ ] Visual check: start a game in dev, confirm the active badge pulses smoothly for both teams and across bidding + playing phases
- [ ] Visual check in mobile preview (`?mobile` query) — both portrait and landscape

🤖 Generated with [Claude Code](https://claude.com/claude-code)