### PR TITLE
feat(stats): add tooltips and make Set Rate team-based

### DIFF
--- a/apps/client/src/components/stats/StatsPage.tsx
+++ b/apps/client/src/components/stats/StatsPage.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
 import type { BidStats, NilStats, RecentGame } from '../../hooks/use-stats';
 import { useStats } from '../../hooks/use-stats';
 
@@ -484,11 +485,13 @@ function BiddingSection({ bidStats }: { bidStats: BidStats }) {
           label="Bid Accuracy"
           value={`${bidStats.bidAccuracy}%`}
           color="#16a34a"
+          tooltip="Percent of rounds where you personally took at least as many tricks as you bid. This is an individual stat — it doesn't account for your partner, so it may differ from whether your team actually made its combined bid (Set Rate, in contrast, is a team-level stat). Overbids still count as accurate here (though the extra tricks become bags). Nil bids are excluded; see Nil Bids below."
         />
         <BidStatCell
           label="Set Rate"
           value={`${bidStats.setBidRate}%`}
           color="#dc2626"
+          tooltip="Percent of rounds where your team was set — you and your partner's combined tricks fell short of your combined bid. Only rounds where you bid a number (not nil) count toward the denominator. If your partner bid nil, only your bid counts toward the team bid. See Nil Bids below for how nil outcomes are tracked."
         />
       </div>
       <div
@@ -509,17 +512,92 @@ function BidStatCell({
   label,
   value,
   color = '#374151',
+  tooltip,
 }: {
   label: string;
   value: string;
   color?: string;
+  tooltip?: string;
 }) {
+  const [rect, setRect] = useState<DOMRect | null>(null);
+
+  const showTooltip = (e: React.SyntheticEvent<HTMLSpanElement>) => {
+    setRect(e.currentTarget.getBoundingClientRect());
+  };
+  const hideTooltip = () => setRect(null);
+
   return (
-    <div style={{ backgroundColor: '#fff', padding: '14px 20px' }}>
+    <div
+      style={{
+        backgroundColor: '#fff',
+        padding: '14px 20px',
+      }}
+    >
       <div style={{ fontSize: '20px', fontWeight: 700, color }}>{value}</div>
-      <div style={{ fontSize: '12px', color: '#6b7280', marginTop: '2px' }}>
+      <div
+        style={{
+          fontSize: '12px',
+          color: '#6b7280',
+          marginTop: '2px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
+        }}
+      >
         {label}
+        {tooltip && (
+          <span
+            onMouseEnter={showTooltip}
+            onMouseLeave={hideTooltip}
+            tabIndex={0}
+            onFocus={showTooltip}
+            onBlur={hideTooltip}
+            aria-label={tooltip}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '13px',
+              height: '13px',
+              borderRadius: '50%',
+              border: '1px solid #9ca3af',
+              color: '#9ca3af',
+              fontSize: '10px',
+              fontWeight: 600,
+              lineHeight: 1,
+              cursor: 'help',
+            }}
+          >
+            ?
+          </span>
+        )}
       </div>
+      {tooltip &&
+        rect &&
+        createPortal(
+          <div
+            role="tooltip"
+            style={{
+              position: 'fixed',
+              top: rect.bottom + 8,
+              left: rect.left + rect.width / 2,
+              transform: 'translateX(-50%)',
+              width: 'min(300px, calc(100vw - 24px))',
+              backgroundColor: '#1f2937',
+              color: '#f9fafb',
+              padding: '10px 14px',
+              borderRadius: '8px',
+              fontSize: '13px',
+              lineHeight: 1.5,
+              boxShadow: '0 10px 30px rgba(0,0,0,0.35)',
+              zIndex: 1000,
+              pointerEvents: 'none',
+            }}
+          >
+            {tooltip}
+          </div>,
+          document.body
+        )}
     </div>
   );
 }

--- a/apps/server/src/db/__tests__/game-results.test.ts
+++ b/apps/server/src/db/__tests__/game-results.test.ts
@@ -417,7 +417,7 @@ describe('game-results', () => {
             avg_tricks: '0',
             met_bid: '0',
             over_bid: '0',
-            under_bid: '0',
+            team_set: '0',
           },
         ],
       });
@@ -426,7 +426,7 @@ describe('game-results', () => {
       expect(stats.totalRounds).toBe(0);
     });
 
-    it('should compute bid accuracy and rates', async () => {
+    it('should compute bid accuracy and team set rate', async () => {
       mockQuery.mockResolvedValueOnce({
         rows: [
           {
@@ -435,7 +435,7 @@ describe('game-results', () => {
             avg_tricks: '3.8',
             met_bid: '7',
             over_bid: '5',
-            under_bid: '3',
+            team_set: '2',
           },
         ],
       });
@@ -444,9 +444,9 @@ describe('game-results', () => {
       expect(stats.totalRounds).toBe(10);
       expect(stats.averageBid).toBe(3.5);
       expect(stats.averageTricks).toBe(3.8);
-      expect(stats.bidAccuracy).toBe(70); // 7/10
+      expect(stats.bidAccuracy).toBe(70); // 7/10 — individual met-or-exceeded-bid
       expect(stats.underbidRate).toBe(50); // 5/10 (over_bid = underbid in UI terminology)
-      expect(stats.setBidRate).toBe(30); // 3/10
+      expect(stats.setBidRate).toBe(20); // 2/10 — team set (fewer than the 3 individual sets because partner covered)
     });
   });
 });

--- a/apps/server/src/db/game-results.ts
+++ b/apps/server/src/db/game-results.ts
@@ -468,19 +468,26 @@ export async function getBidStats(userId: string): Promise<BidStats> {
     avg_tricks: string;
     met_bid: string;
     over_bid: string;
-    under_bid: string;
+    team_set: string;
   }>(
     `SELECT
        COUNT(*)::text AS total_rounds,
-       COALESCE(AVG(bid)::numeric(4,1)::text, '0') AS avg_bid,
-       COALESCE(AVG(tricks_won)::numeric(4,1)::text, '0') AS avg_tricks,
-       COUNT(*) FILTER (WHERE tricks_won >= bid)::text AS met_bid,
-       COUNT(*) FILTER (WHERE tricks_won > bid)::text AS over_bid,
-       COUNT(*) FILTER (WHERE tricks_won < bid)::text AS under_bid
-     FROM round_bids
-     WHERE player_id = $1
-       AND NOT is_nil
-       AND NOT is_blind_nil`,
+       COALESCE(AVG(rb.bid)::numeric(4,1)::text, '0') AS avg_bid,
+       COALESCE(AVG(rb.tricks_won)::numeric(4,1)::text, '0') AS avg_tricks,
+       COUNT(*) FILTER (WHERE rb.tricks_won >= rb.bid)::text AS met_bid,
+       COUNT(*) FILTER (WHERE rb.tricks_won > rb.bid)::text AS over_bid,
+       COUNT(*) FILTER (
+         WHERE (rb.tricks_won + partner.tricks_won) <
+               (rb.bid + CASE WHEN partner.is_nil OR partner.is_blind_nil THEN 0 ELSE partner.bid END)
+       )::text AS team_set
+     FROM round_bids rb
+     JOIN round_bids partner
+       ON partner.game_result_id = rb.game_result_id
+      AND partner.round_number = rb.round_number
+      AND partner.player_position = (rb.player_position + 2) % 4
+     WHERE rb.player_id = $1
+       AND NOT rb.is_nil
+       AND NOT rb.is_blind_nil`,
     [userId]
   );
 
@@ -490,7 +497,7 @@ export async function getBidStats(userId: string): Promise<BidStats> {
 
   const metBid = parseInt(row.met_bid, 10);
   const overBid = parseInt(row.over_bid, 10);
-  const underBid = parseInt(row.under_bid, 10);
+  const teamSet = parseInt(row.team_set, 10);
 
   return {
     totalRounds,
@@ -498,6 +505,6 @@ export async function getBidStats(userId: string): Promise<BidStats> {
     averageTricks: parseFloat(row.avg_tricks),
     bidAccuracy: Math.round((metBid / totalRounds) * 100),
     underbidRate: Math.round((overBid / totalRounds) * 100),
-    setBidRate: Math.round((underBid / totalRounds) * 100),
+    setBidRate: Math.round((teamSet / totalRounds) * 100),
   };
 }


### PR DESCRIPTION
## Summary

- Adds hover tooltips to the **Bid Accuracy** and **Set Rate** cells on the stats page, triggered by hovering the `?` icon beside each label. Tooltips render via a React portal so they escape the card's `overflow: hidden`, and they're keyboard-accessible via `tabIndex` + `aria-label`.
- Changes **Set Rate** from an individual-level stat (were my personal tricks fewer than my personal bid?) to a true team-level stat (was my team set?). The query self-joins `round_bids` against the partner's row and counts rounds where the combined tricks fell short of the combined bid — matching the scoring logic in `scoring.ts:44-51`. If your partner bid nil, their bid contributes 0 to the team bid, consistent with how scoring handles nils.
- **Bid Accuracy** remains an individual stat for now; the tooltip explicitly calls out the asymmetry so users aren't surprised.

### Why

Users were confused about what these stats meant. The example that surfaced the bug: "I bid 3, partner bids 3, I take 2, partner takes 4 — the team made it, but the old Set Rate counted that against me."

## Test plan

- [x] `pnpm test` — all 557 unit tests pass, including updated `getBidStats` assertions.
- [x] `pnpm --filter @spades/client exec tsc --noEmit` — client typechecks clean.
- [x] `pnpm --filter @spades/server exec tsc --noEmit` — server typechecks clean.
- [ ] Manual: hover the `?` on Bid Accuracy and Set Rate in `/stats`; confirm tooltip appears immediately below the icon and is readable.
- [ ] Manual: tab to the `?` with the keyboard; confirm the tooltip also appears on focus.
- [ ] Manual with real data: confirm Set Rate is lower than the old individual set rate in rounds where the partner covered an undertrick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)