### PR TITLE
refactor: remove dead code

### DIFF
--- a/apps/server/src/game/game-instance.ts
+++ b/apps/server/src/game/game-instance.ts
@@ -360,13 +360,4 @@ export class GameInstance {
       newPosition,
     });
   }
-
-  isPlayerTurn(playerId: PlayerId): boolean {
-    const player = this.state.players.find((p) => p.id === playerId);
-    return player?.position === this.state.currentPlayerPosition;
-  }
-
-  getPlayerByPosition(position: number): PlayerId | undefined {
-    return this.state.players.find((p) => p.position === position)?.id;
-  }
 }

--- a/packages/shared/src/__tests__/bidding.test.ts
+++ b/packages/shared/src/__tests__/bidding.test.ts
@@ -4,7 +4,6 @@ import {
   getNextBidder,
   allBidsComplete,
   createBid,
-  getTeamTotalBid,
 } from '../game-logic/bidding';
 import {
   createInitialGameState,
@@ -444,47 +443,6 @@ describe('bidding', () => {
       const bid = createBid('p1', 7, false, true);
       expect(bid.bid).toBe(0);
       expect(bid.isBlindNil).toBe(true);
-    });
-  });
-
-  describe('getTeamTotalBid', () => {
-    it('should sum bids for specified player IDs', () => {
-      const bids: PlayerBid[] = [
-        { playerId: 'p0', bid: 3, isNil: false, isBlindNil: false },
-        { playerId: 'p1', bid: 4, isNil: false, isBlindNil: false },
-        { playerId: 'p2', bid: 5, isNil: false, isBlindNil: false },
-        { playerId: 'p3', bid: 2, isNil: false, isBlindNil: false },
-      ];
-      expect(getTeamTotalBid(bids, ['p0', 'p2'])).toBe(8);
-      expect(getTeamTotalBid(bids, ['p1', 'p3'])).toBe(6);
-    });
-
-    it('should exclude nil bids from team total', () => {
-      const bids: PlayerBid[] = [
-        { playerId: 'p0', bid: 0, isNil: true, isBlindNil: false },
-        { playerId: 'p2', bid: 5, isNil: false, isBlindNil: false },
-      ];
-      expect(getTeamTotalBid(bids, ['p0', 'p2'])).toBe(5);
-    });
-
-    it('should exclude blind nil bids from team total', () => {
-      const bids: PlayerBid[] = [
-        { playerId: 'p0', bid: 0, isNil: false, isBlindNil: true },
-        { playerId: 'p2', bid: 4, isNil: false, isBlindNil: false },
-      ];
-      expect(getTeamTotalBid(bids, ['p0', 'p2'])).toBe(4);
-    });
-
-    it('should return 0 when both teammates bid nil', () => {
-      const bids: PlayerBid[] = [
-        { playerId: 'p0', bid: 0, isNil: true, isBlindNil: false },
-        { playerId: 'p2', bid: 0, isNil: false, isBlindNil: true },
-      ];
-      expect(getTeamTotalBid(bids, ['p0', 'p2'])).toBe(0);
-    });
-
-    it('should return 0 for empty bids array', () => {
-      expect(getTeamTotalBid([], ['p0', 'p2'])).toBe(0);
     });
   });
 });

--- a/packages/shared/src/__tests__/deck.test.ts
+++ b/packages/shared/src/__tests__/deck.test.ts
@@ -7,7 +7,6 @@ import {
   removeCardFromHand,
   hasCard,
   hasSuit,
-  getCardsOfSuit,
   hasOnlySpades,
 } from '../game-logic/deck';
 import type { Card } from '../types/card';
@@ -146,21 +145,6 @@ describe('Deck', () => {
     it('should return false if hand has no cards of the suit', () => {
       const hand: Card[] = [{ suit: 'spades', rank: 'A' }];
       expect(hasSuit(hand, 'hearts')).toBe(false);
-    });
-  });
-
-  describe('getCardsOfSuit', () => {
-    it('should return all cards of the specified suit', () => {
-      const hand: Card[] = [
-        { suit: 'spades', rank: 'A' },
-        { suit: 'spades', rank: 'K' },
-        { suit: 'hearts', rank: 'Q' },
-      ];
-
-      const spades = getCardsOfSuit(hand, 'spades');
-      expect(spades).toHaveLength(2);
-      expect(spades).toContainEqual({ suit: 'spades', rank: 'A' });
-      expect(spades).toContainEqual({ suit: 'spades', rank: 'K' });
     });
   });
 

--- a/packages/shared/src/__tests__/trick.test.ts
+++ b/packages/shared/src/__tests__/trick.test.ts
@@ -3,7 +3,6 @@ import {
   determineTrickWinner,
   addPlayToTrick,
   isTrickComplete,
-  hasSpadeBeenPlayedInTrick,
 } from '../game-logic/trick';
 import type { Trick } from '../types/game-state';
 
@@ -131,29 +130,6 @@ describe('Trick', () => {
         winner: 'p2',
       };
       expect(isTrickComplete(trick)).toBe(true);
-    });
-  });
-
-  describe('hasSpadeBeenPlayedInTrick', () => {
-    it('should return false if no spades played', () => {
-      const trick: Trick = {
-        plays: [{ playerId: 'p1', card: { suit: 'hearts', rank: 'A' } }],
-        leadSuit: 'hearts',
-        winner: null,
-      };
-      expect(hasSpadeBeenPlayedInTrick(trick)).toBe(false);
-    });
-
-    it('should return true if spade was played', () => {
-      const trick: Trick = {
-        plays: [
-          { playerId: 'p1', card: { suit: 'hearts', rank: 'A' } },
-          { playerId: 'p2', card: { suit: 'spades', rank: '2' } },
-        ],
-        leadSuit: 'hearts',
-        winner: null,
-      };
-      expect(hasSpadeBeenPlayedInTrick(trick)).toBe(true);
     });
   });
 });

--- a/packages/shared/src/game-logic/bidding.ts
+++ b/packages/shared/src/game-logic/bidding.ts
@@ -103,12 +103,3 @@ export function createBid(
     isBlindNil,
   };
 }
-
-export function getTeamTotalBid(
-  bids: PlayerBid[],
-  playerIds: PlayerId[]
-): number {
-  return bids
-    .filter((b) => playerIds.includes(b.playerId) && !b.isNil && !b.isBlindNil)
-    .reduce((sum, b) => sum + b.bid, 0);
-}

--- a/packages/shared/src/game-logic/deck.ts
+++ b/packages/shared/src/game-logic/deck.ts
@@ -81,10 +81,6 @@ export function hasSuit(hand: Card[], suit: Suit): boolean {
   return hand.some((c) => c.suit === suit);
 }
 
-export function getCardsOfSuit(hand: Card[], suit: Suit): Card[] {
-  return hand.filter((c) => c.suit === suit);
-}
-
 export function hasOnlySpades(hand: Card[]): boolean {
   return hand.every((c) => c.suit === 'spades');
 }

--- a/packages/shared/src/game-logic/index.ts
+++ b/packages/shared/src/game-logic/index.ts
@@ -7,5 +7,4 @@ export {
   getNextBidder,
   allBidsComplete,
   createBid,
-  getTeamTotalBid,
 } from './bidding.js';

--- a/packages/shared/src/game-logic/trick.ts
+++ b/packages/shared/src/game-logic/trick.ts
@@ -1,4 +1,3 @@
-import type { Card } from '../types/card.js';
 import { compareCards } from '../types/card.js';
 import type { Trick } from '../types/game-state.js';
 import type { PlayerId, PlayerTrickPlay } from '../types/player.js';
@@ -36,20 +35,4 @@ export function addPlayToTrick(trick: Trick, play: PlayerTrickPlay): Trick {
 
 export function isTrickComplete(trick: Trick): boolean {
   return trick.plays.length === 4;
-}
-
-export function getHighestCardInTrick(trick: Trick): Card | null {
-  if (trick.plays.length === 0 || !trick.leadSuit) return null;
-
-  let highest = trick.plays[0].card;
-  for (let i = 1; i < trick.plays.length; i++) {
-    if (compareCards(trick.plays[i].card, highest, trick.leadSuit) > 0) {
-      highest = trick.plays[i].card;
-    }
-  }
-  return highest;
-}
-
-export function hasSpadeBeenPlayedInTrick(trick: Trick): boolean {
-  return trick.plays.some((p) => p.card.suit === 'spades');
 }

--- a/packages/shared/src/types/card.ts
+++ b/packages/shared/src/types/card.ts
@@ -52,42 +52,6 @@ export const RANK_VALUES: Record<Rank, number> = {
   A: 14,
 };
 
-export function cardToString(card: Card): string {
-  return `${card.rank}${card.suit[0].toUpperCase()}`;
-}
-
-export function parseCard(str: string): Card | null {
-  const match = /^(10|[2-9JQKA])([SHDC])$/i.exec(str);
-  if (!match) return null;
-
-  const rankMap: Record<string, Rank> = {
-    '2': '2',
-    '3': '3',
-    '4': '4',
-    '5': '5',
-    '6': '6',
-    '7': '7',
-    '8': '8',
-    '9': '9',
-    '10': '10',
-    J: 'J',
-    Q: 'Q',
-    K: 'K',
-    A: 'A',
-  };
-  const suitMap: Record<string, Suit> = {
-    S: 'spades',
-    H: 'hearts',
-    D: 'diamonds',
-    C: 'clubs',
-  };
-
-  return {
-    rank: rankMap[match[1].toUpperCase()],
-    suit: suitMap[match[2].toUpperCase()],
-  };
-}
-
 export function compareCards(a: Card, b: Card, leadSuit: Suit): number {
   const aIsSpade = a.suit === 'spades';
   const bIsSpade = b.suit === 'spades';


### PR DESCRIPTION
## Summary

Removes functions that have no references anywhere in application code, surfaced during a codebase review. Includes functions that were referenced **only by their own unit tests** — those tests are removed alongside them.

### Removed
| Symbol | File |
|---|---|
| `GameInstance.isPlayerTurn` | `apps/server/src/game/game-instance.ts` |
| `GameInstance.getPlayerByPosition` | `apps/server/src/game/game-instance.ts` |
| `getHighestCardInTrick` | `packages/shared/src/game-logic/trick.ts` |
| `hasSpadeBeenPlayedInTrick` *(test-only)* | `packages/shared/src/game-logic/trick.ts` |
| `cardToString` | `packages/shared/src/types/card.ts` |
| `parseCard` | `packages/shared/src/types/card.ts` |
| `getCardsOfSuit` *(test-only)* | `packages/shared/src/game-logic/deck.ts` |
| `getTeamTotalBid` *(test-only)* | `packages/shared/src/game-logic/bidding.ts` (+ barrel re-export) |

Also drops the now-unused `Card` type import in `trick.ts`.

## Testing
- `pnpm build` — clean
- `pnpm test` — 541 unit tests pass
- `eslint` — no errors, no new warnings

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)