### PR TITLE
fix: repair three lifecycle bugs (stuck play guard, idle-timer leak, dead callback arg)

### DIFF
--- a/apps/client/src/hooks/use-game.ts
+++ b/apps/client/src/hooks/use-game.ts
@@ -138,6 +138,10 @@ export function useGame() {
       setHand(hand);
       setScoreHistory(scoreHistory);
       revealCards();
+      // A reconnect resyncs full state from the server; any play that was
+      // in flight when we dropped is now moot. Clear the guard so the
+      // resynced hand is playable.
+      playPendingRef.current = false;
     });
 
     socket.on('room:seat-changed', ({ newPosition }) => {
@@ -167,9 +171,12 @@ export function useGame() {
 
     socket.on('error', ({ code, message }) => {
       console.error(`[game] error code=${code} message=${message}`);
-      if (code === 'INVALID_PLAY' || code === 'PLAY_FAILED') {
-        playPendingRef.current = false;
-      }
+      // Any server error means an in-flight play (if there was one) did not
+      // complete. INVALID_PLAY / PLAY_FAILED are the expected play-rejection
+      // codes, but clearing the guard unconditionally prevents an unrelated
+      // error from leaving it stuck `true` and silently locking the player
+      // out of playing for the rest of the game.
+      playPendingRef.current = false;
       const { setError } = useGameStore.getState();
       setError(message);
       setTimeout(() => setError(null), 5000);

--- a/apps/server/src/rooms/__tests__/room-manager.test.ts
+++ b/apps/server/src/rooms/__tests__/room-manager.test.ts
@@ -145,6 +145,25 @@ describe('RoomManager', () => {
       expect(found?.playerId).toBe('player-3');
       expect(found?.roomId).toBe(room1.id);
     });
+
+    it('should fire onRoomDeleted so per-room state can be cleaned up', () => {
+      const room = rm.createRoom();
+      const callback = vi.fn();
+      rm.onRoomDeleted = callback;
+
+      rm.deleteRoom(room.id);
+
+      expect(callback).toHaveBeenCalledWith(room.id);
+    });
+
+    it('should not fire onRoomDeleted for an unknown room', () => {
+      const callback = vi.fn();
+      rm.onRoomDeleted = callback;
+
+      rm.deleteRoom('NOEXIST');
+
+      expect(callback).not.toHaveBeenCalled();
+    });
   });
 
   describe('touchRoom', () => {
@@ -549,7 +568,7 @@ describe('RoomManager', () => {
       rm.markSessionDisconnected('sock-2');
       vi.advanceTimersByTime(6 * 60 * 1000);
 
-      expect(callback).toHaveBeenCalledWith(room.id, 'p2');
+      expect(callback).toHaveBeenCalledWith(room.id);
     });
 
     it('should not invoke onSessionAbandoned for waiting rooms', () => {

--- a/apps/server/src/rooms/room-manager.ts
+++ b/apps/server/src/rooms/room-manager.ts
@@ -28,7 +28,11 @@ export class RoomManager {
   private sessions = new Map<string, PlayerSession>();
   private socketToSession = new Map<string, string>();
 
-  onSessionAbandoned?: (roomId: string, playerId: string) => void;
+  onSessionAbandoned?: (roomId: string) => void;
+
+  // Fired whenever a room is removed, so external per-room state (e.g. the
+  // idle timer's turn map) can be cleaned up and not leak entries.
+  onRoomDeleted?: (roomId: string) => void;
 
   constructor() {
     // Cleanup expired rooms periodically
@@ -218,6 +222,7 @@ export class RoomManager {
         }
       }
       this.rooms.delete(roomId);
+      this.onRoomDeleted?.(roomId);
     }
   }
 
@@ -329,9 +334,11 @@ export class RoomManager {
         this.sessions.delete(token);
         deletedSessions++;
 
-        // Notify handler so it can broadcast the seat becoming open
+        // Notify handler so it can broadcast the seat becoming open. The
+        // handler re-derives open seats from room state, so only the roomId
+        // is needed here.
         if (isActiveGame && this.onSessionAbandoned) {
-          this.onSessionAbandoned(session.roomId, session.playerId);
+          this.onSessionAbandoned(session.roomId);
         }
       }
     }
@@ -354,7 +361,7 @@ export class RoomManager {
         console.log(
           `[cleanup] deleting orphaned room=${roomId} phase=${phase} — all sessions expired`
         );
-        this.rooms.delete(roomId);
+        this.deleteRoom(roomId);
         deletedRooms++;
       }
     }

--- a/apps/server/src/socket/handler.ts
+++ b/apps/server/src/socket/handler.ts
@@ -101,6 +101,12 @@ export function setupSocketHandlers(io: TypedServer): void {
     }
   };
 
+  // When a room is deleted, drop its idle-timer entry so the turn map doesn't
+  // leak entries for rooms that no longer exist.
+  roomManager.onRoomDeleted = (roomId: string) => {
+    idleTimer.removeRoom(roomId);
+  };
+
   io.on('connection', (socket: TypedSocket) => {
     console.log(
       `[socket] connected id=${socket.id} transport=${socket.conn.transport.name}`


### PR DESCRIPTION
Fixes three latent lifecycle bugs found in the comprehensive code review (findings #1–#3).

## 1. `playPendingRef` could stick `true` and lock a player out of playing
`playCard` sets `playPendingRef.current = true` to guard against double-emits during the server round-trip, but it was only cleared on the local `game:card-played` confirmation or on the `INVALID_PLAY` / `PLAY_FAILED` error codes. Any **other** error code while a play was pending — or a socket drop mid-play — left the guard stuck `true`, after which `playCard` early-returns forever and the player can't play another card for the rest of the game (refresh only).

**Fix:** clear the guard on **any** `error` event, and on `reconnect:success` (a reconnect resyncs full state, so any in-flight play is moot). Setting it `false` when already `false` is a no-op; the server remains authoritative on out-of-turn/duplicate plays, so broadening the reset doesn't weaken correctness.

## 2. `IdleTimerManager.turns` leaked one entry per deleted room
The idle timer's `turns` map is keyed by `roomId`, but room deletion in `room-manager.ts` never told the timer to drop the entry — `removeRoom()` existed but was **dead code**, and orphaned active-game rooms were deleted via a raw `this.rooms.delete()` that bypassed `deleteRoom()` entirely.

**Fix:** add an `onRoomDeleted` callback fired from `deleteRoom()`, route the orphaned-room cleanup through `deleteRoom()` so every deletion path is centralized, and wire the handler to call `idleTimer.removeRoom(roomId)`. Mirrors the existing `onSessionAbandoned` pattern.

## 3. `onSessionAbandoned` signature mismatch
The callback type was `(roomId, playerId) => void` and the call site passed both, but the only consumer (handler.ts) takes just `roomId` and re-derives abandoned seats from room state — `playerId` was dead data flow.

**Fix:** drop the unused `playerId` from the type and call site; update the test assertion.

## Testing
- `pnpm build` clean, `pnpm lint` 0 errors, `pnpm knip` green
- Unit: server 250, shared 210, client 47 — all pass (added 2 tests for the `onRoomDeleted` callback)
- E2E: 35 passed (1 unrelated flaky in `bidding.spec.ts`, passed on retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)