### PR TITLE
refactor(scoring): extract shared team-round scoring helper

### DIFF
--- a/packages/shared/src/game-logic/scoring.ts
+++ b/packages/shared/src/game-logic/scoring.ts
@@ -58,16 +58,35 @@ export function calculateRoundScore(
   };
 }
 
+// Bag penalty applied when a team's accumulated bags cross the threshold.
+// Returns both the penalty (to subtract from the score) and the bags left
+// after the threshold rolls over. Shared by updateTeamScore (which applies
+// the penalty) and createRoundSummary (which displays it) so the score shown
+// and the score applied can never disagree.
+function applyBagPenalty(
+  currentBags: number,
+  roundBags: number,
+  config: GameConfig
+): { bagPenalty: number; remainingBags: number } {
+  const newBags = currentBags + roundBags;
+  const penaltyCount = Math.floor(newBags / config.bagPenaltyThreshold);
+  const bagPenalty = penaltyCount * config.bagPenalty;
+  const remainingBags =
+    penaltyCount > 0 ? newBags % config.bagPenaltyThreshold : newBags;
+
+  return { bagPenalty, remainingBags };
+}
+
 export function updateTeamScore(
   currentScore: TeamScore,
   roundCalculation: ScoreCalculation,
   config: GameConfig
 ): TeamScore {
-  const newBags = currentScore.bags + roundCalculation.bags;
-  const penaltyCount = Math.floor(newBags / config.bagPenaltyThreshold);
-  const bagPenalty = penaltyCount * config.bagPenalty;
-  const remainingBags =
-    penaltyCount > 0 ? newBags % config.bagPenaltyThreshold : newBags;
+  const { bagPenalty, remainingBags } = applyBagPenalty(
+    currentScore.bags,
+    roundCalculation.bags,
+    config
+  );
 
   return {
     ...currentScore,
@@ -78,6 +97,45 @@ export function updateTeamScore(
   };
 }
 
+// Aggregates one team's bids and tricks for the current round and computes
+// its score. Shared by createRoundSummary (for the display summary) and the
+// state machine's round-completion handler (to apply the score) so the two
+// paths can never drift apart.
+export function calculateTeamRoundScore(
+  gameState: GameState,
+  teamId: TeamId,
+  playerTricks: Record<PlayerId, number>
+): {
+  regularBid: number;
+  teamTricks: number;
+  nilBids: PlayerBid[];
+  scoreCalc: ScoreCalculation;
+} {
+  const teamPlayers = gameState.players.filter((p) => p.team === teamId);
+  const teamBids = gameState.currentRound!.bids.filter((b) =>
+    teamPlayers.some((p) => p.id === b.playerId)
+  );
+
+  const nilBids = teamBids.filter((b) => b.isNil || b.isBlindNil);
+  const regularBid = teamBids
+    .filter((b) => !b.isNil && !b.isBlindNil)
+    .reduce((sum, b) => sum + b.bid, 0);
+
+  const teamTricks = teamPlayers.reduce(
+    (sum, p) => sum + (playerTricks[p.id] || 0),
+    0
+  );
+
+  const scoreCalc = calculateRoundScore(
+    regularBid,
+    teamTricks,
+    nilBids,
+    playerTricks
+  );
+
+  return { regularBid, teamTricks, nilBids, scoreCalc };
+}
+
 export function createRoundSummary(
   gameState: GameState,
   playerTricks: Record<PlayerId, number>,
@@ -86,27 +144,8 @@ export function createRoundSummary(
   const round = gameState.currentRound!;
 
   const createTeamResult = (teamId: TeamId): TeamRoundResult => {
-    const teamPlayers = gameState.players.filter((p) => p.team === teamId);
-    const teamBids = round.bids.filter((b) =>
-      teamPlayers.some((p) => p.id === b.playerId)
-    );
-
-    const nilBids = teamBids.filter((b) => b.isNil || b.isBlindNil);
-    const regularBid = teamBids
-      .filter((b) => !b.isNil && !b.isBlindNil)
-      .reduce((sum, b) => sum + b.bid, 0);
-
-    const teamTricks = teamPlayers.reduce(
-      (sum, p) => sum + (playerTricks[p.id] || 0),
-      0
-    );
-
-    const scoreCalc = calculateRoundScore(
-      regularBid,
-      teamTricks,
-      nilBids,
-      playerTricks
-    );
+    const { regularBid, teamTricks, nilBids, scoreCalc } =
+      calculateTeamRoundScore(gameState, teamId, playerTricks);
 
     const nilResults = nilBids.map((nb) => ({
       playerId: nb.playerId,
@@ -120,10 +159,11 @@ export function createRoundSummary(
           : -(nb.isBlindNil ? 200 : 100),
     }));
 
-    const currentTeamScore = gameState.scores[teamId];
-    const newBags = currentTeamScore.bags + scoreCalc.bags;
-    const penaltyCount = Math.floor(newBags / config.bagPenaltyThreshold);
-    const bagPenalty = penaltyCount * config.bagPenalty;
+    const { bagPenalty } = applyBagPenalty(
+      gameState.scores[teamId].bags,
+      scoreCalc.bags,
+      config
+    );
 
     return {
       bid: regularBid,

--- a/packages/shared/src/state-machine/game-machine.ts
+++ b/packages/shared/src/state-machine/game-machine.ts
@@ -5,7 +5,7 @@ import {
   removeCardFromHand,
 } from '../game-logic/deck.js';
 import {
-  calculateRoundScore,
+  calculateTeamRoundScore,
   updateTeamScore,
   checkGameEnd,
   createRoundSummary,
@@ -554,30 +554,14 @@ function handleEndRound(state: GameState, config: GameConfig): ActionResult {
     }
   }
 
-  // Calculate scores for each team
-  const calculateTeamScore = (teamId: 'team1' | 'team2') => {
-    const teamPlayers = state.players.filter((p) => p.team === teamId);
-    const teamBids = state.currentRound!.bids.filter((b) =>
-      teamPlayers.some((p) => p.id === b.playerId)
-    );
-    const nilBids = teamBids.filter((b) => b.isNil || b.isBlindNil);
-    const regularBid = teamBids
-      .filter((b) => !b.isNil && !b.isBlindNil)
-      .reduce((sum, b) => sum + b.bid, 0);
-    const teamTricks = teamPlayers.reduce(
-      (sum, p) => sum + playerTricks[p.id],
-      0
-    );
-
-    return calculateRoundScore(regularBid, teamTricks, nilBids, playerTricks);
-  };
-
-  const team1Calc = calculateTeamScore('team1');
-  const team2Calc = calculateTeamScore('team2');
+  // Calculate scores for each team. The per-team aggregation lives in
+  // calculateTeamRoundScore so this path and createRoundSummary stay in sync.
+  const team1Calc = calculateTeamRoundScore(state, 'team1', playerTricks);
+  const team2Calc = calculateTeamRoundScore(state, 'team2', playerTricks);
 
   const newScores = {
-    team1: updateTeamScore(state.scores.team1, team1Calc, config),
-    team2: updateTeamScore(state.scores.team2, team2Calc, config),
+    team1: updateTeamScore(state.scores.team1, team1Calc.scoreCalc, config),
+    team2: updateTeamScore(state.scores.team2, team2Calc.scoreCalc, config),
   };
 
   const winner = checkGameEnd(newScores, state.winningScore);


### PR DESCRIPTION
Addresses duplicated team-scoring logic across `scoring.ts` and `game-machine.ts`.

## The duplication
The per-team round aggregation was copy-pasted in two places:
- `game-machine.ts` `handleCompleteRound` → `calculateTeamScore` closure (applies the score)
- `scoring.ts` `createRoundSummary` → `createTeamResult` (builds the display summary)

Both did the identical sequence: filter players by team → filter their bids → split nil vs regular → sum the regular bid → sum team tricks → call `calculateRoundScore`. Any change to scoring rules had to be made in both, or the score *applied* and the score *shown* would silently diverge.

A second, smaller duplication: the bag-penalty formula (`floor(newBags / threshold) * penalty`) lived in both `updateTeamScore` (applies it) and `createRoundSummary` (displays it).

## The fix
- **`calculateTeamRoundScore(gameState, teamId, playerTricks)`** (exported) — the per-team aggregation, returning `{ regularBid, teamTricks, nilBids, scoreCalc }`. Used by both the state machine and `createRoundSummary`.
- **`applyBagPenalty(currentBags, roundBags, config)`** (module-private) — returns `{ bagPenalty, remainingBags }`. Used by both `updateTeamScore` and `createRoundSummary`.

`game-machine.ts` loses its 16-line closure (two helper calls instead) and swaps its now-unused `calculateRoundScore` import for `calculateTeamRoundScore`.

## Testing
- `pnpm build` clean, `pnpm lint` 0 errors, `pnpm knip` green
- Unit: 210 shared + 250 server, all pass (existing tests fully cover round scoring + completion; no assertions needed updating → confirms no behavior change)
- E2E: 36 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)