### PR TITLE
fix(auth): read returnTo before passport regenerates the session

### DIFF
--- a/apps/server/src/auth/__tests__/auth-routes.test.ts
+++ b/apps/server/src/auth/__tests__/auth-routes.test.ts
@@ -1,0 +1,108 @@
+import type { Server } from 'node:http';
+import express from 'express';
+import session from 'express-session';
+import passport from 'passport';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// A minimal passport strategy named 'google' so we can exercise the real
+// authRouter without hitting Google. On the initiate request it redirects
+// (like the real OAuth2 strategy); on the callback it succeeds, which makes
+// passport call req.login() → req.session.regenerate(). That regeneration is
+// the exact mechanism that wiped `returnTo` and is what this test guards.
+class MockGoogleStrategy {
+  name = 'google';
+  authenticate(this: passport.Strategy, req: express.Request) {
+    if (req.path.includes('/callback')) {
+      // self.success is provided by passport at runtime
+      (this as unknown as { success: (u: unknown) => void }).success({
+        id: 'u1',
+        email: 'a@b.com',
+        displayName: 'A',
+      });
+    } else {
+      (this as unknown as { redirect: (url: string) => void }).redirect(
+        'https://accounts.google.com/o/oauth2/v2/auth'
+      );
+    }
+  }
+}
+
+async function startServer(): Promise<{ server: Server; baseUrl: string }> {
+  // Required for `oauthConfigured` to be true at import time.
+  process.env.GOOGLE_CLIENT_ID = 'test-id';
+  process.env.GOOGLE_CLIENT_SECRET = 'test-secret';
+  process.env.DATABASE_URL = 'postgres://test';
+  process.env.NODE_ENV = 'production';
+
+  passport.use(new MockGoogleStrategy() as unknown as passport.Strategy);
+  passport.serializeUser((user, done) => done(null, user));
+  passport.deserializeUser((obj: Express.User, done) => done(null, obj));
+
+  const { authRouter } = await import('../auth-routes.js');
+
+  const app = express();
+  app.use(
+    session({
+      secret: 'test-secret',
+      resave: false,
+      saveUninitialized: false,
+    })
+  );
+  app.use(passport.initialize());
+  app.use(passport.session());
+  app.use('/auth', authRouter);
+
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const addr = server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  return { server, baseUrl: `http://127.0.0.1:${port}` };
+}
+
+describe('OAuth returnTo redirect', () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    ({ server, baseUrl } = await startServer());
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  async function loginFlow(returnToQuery: string): Promise<string | null> {
+    // 1. Initiate: stores returnTo in the session, sets the session cookie.
+    const initiate = await fetch(`${baseUrl}/auth/google${returnToQuery}`, {
+      redirect: 'manual',
+    });
+    const cookie = initiate.headers.get('set-cookie')?.split(';')[0] ?? '';
+
+    // 2. Callback: passport logs in (regenerating the session) then redirects.
+    const callback = await fetch(`${baseUrl}/auth/google/callback`, {
+      redirect: 'manual',
+      headers: { cookie },
+    });
+    return callback.headers.get('location');
+  }
+
+  it('redirects back to the original room URL after login', async () => {
+    const location = await loginFlow(
+      `?returnTo=${encodeURIComponent('/room/ABC123')}`
+    );
+    expect(location).toBe('/room/ABC123');
+  });
+
+  it('redirects to / when no returnTo was provided', async () => {
+    const location = await loginFlow('');
+    expect(location).toBe('/');
+  });
+
+  it('ignores a protocol-relative returnTo (open-redirect guard)', async () => {
+    const location = await loginFlow(
+      `?returnTo=${encodeURIComponent('//evil.com')}`
+    );
+    expect(location).toBe('/');
+  });
+});

--- a/apps/server/src/auth/auth-routes.ts
+++ b/apps/server/src/auth/auth-routes.ts
@@ -60,6 +60,11 @@ authRouter.get('/google/callback', (req, res, _next) => {
     res.status(503).send('OAuth not configured on this server.');
     return;
   }
+  // Capture returnTo from the *pre-login* session. passport's req.login()
+  // (in passport >= 0.6) regenerates the session to guard against session
+  // fixation, which discards everything we stored before the OAuth redirect.
+  // Reading it here, before passport.authenticate runs, preserves it.
+  const returnTo = req.session.returnTo;
   passport.authenticate('google', { failureMessage: true, session: true })(
     req,
     res,
@@ -71,8 +76,6 @@ authRouter.get('/google/callback', (req, res, _next) => {
         res.redirect('/?error=not_allowed');
         return;
       }
-      const returnTo = req.session.returnTo;
-      delete req.session.returnTo;
       res.redirect(returnTo ?? '/');
     }
   );


### PR DESCRIPTION
## Summary

Follow-up to #82. A user reported the share-link redirect bug **persisted** after that fix: visiting `/room/ABC123` while logged out still lands on `/` after Google login.

### Root cause

#82 stored `req.session.returnTo` before the OAuth redirect and read it back in the callback. That looked correct, but we're on **passport 0.7**, and since passport 0.6 `req.login()` calls `req.session.regenerate()` to guard against session fixation. Regeneration creates a fresh session and only re-adds the passport user — so `returnTo` was **destroyed before the callback ever read it**. The read always returned `undefined`, falling through to `/`.

Confirmed against `passport/lib/sessionmanager.js`:

```js
req.session.regenerate(function (err) {       // wipes returnTo
  ...
  if (options.keepSessionInfo) { merge(req.session, prevSession); }  // not set
```

### Fix

Capture `returnTo` into a local at the **top of the callback handler, before `passport.authenticate` runs** — i.e. before regeneration — and redirect using that local. One-line reordering.

### Test

Added `apps/server/src/auth/__tests__/auth-routes.test.ts`: a real `express-session` (MemoryStore) + a mock passport `'google'` strategy that triggers the same `req.login()` → `regenerate()` path, driving the initiate→callback flow over `fetch`. Verified it **fails against the pre-fix ordering** (redirects to `/`) and **passes with the fix**. Also covers the no-`returnTo` and protocol-relative open-redirect-guard cases.

## Test plan
- [x] `pnpm --filter @spades/server test` — 263 passing (3 new)
- [x] New test fails on buggy ordering, passes on fix
- [ ] Manual: visit `/room/ABCDEF` logged out → Google login → land on `/room/ABCDEF`

🤖 Generated with [Claude Code](https://claude.com/claude-code)