### PR TITLE
feat(stats): team-level bid/trick stats + avg bags

### DIFF
--- a/apps/client/src/components/stats/StatsPage.tsx
+++ b/apps/client/src/components/stats/StatsPage.tsx
@@ -476,22 +476,27 @@ function BiddingSection({ bidStats }: { bidStats: BidStats }) {
           backgroundColor: '#e5e7eb',
         }}
       >
-        <BidStatCell label="Avg Bid" value={bidStats.averageBid.toFixed(1)} />
         <BidStatCell
-          label="Avg Tricks"
-          value={bidStats.averageTricks.toFixed(1)}
+          label="Avg Bid (you / team)"
+          value={`${bidStats.individualAvgBid.toFixed(1)} / ${bidStats.teamAvgBid.toFixed(1)}`}
+          tooltip="Your average bid per round (left) and your team's combined bid — you plus your partner (right). Nil and blind-nil hands count as a bid of 0."
         />
         <BidStatCell
-          label="Bid Accuracy"
-          value={`${bidStats.bidAccuracy}%`}
-          color="#16a34a"
-          tooltip="Percent of rounds where you personally took at least as many tricks as you bid. This is an individual stat — it doesn't account for your partner, so it may differ from whether your team actually made its combined bid (Set Rate, in contrast, is a team-level stat). Overbids still count as accurate here (though the extra tricks become bags). Nil bids are excluded; see Nil Bids below."
+          label="Avg Tricks (you / team)"
+          value={`${bidStats.individualAvgTricks.toFixed(1)} / ${bidStats.teamAvgTricks.toFixed(1)}`}
+          tooltip="Your average tricks taken per round (left) and your team's combined tricks (right). Nil hands are included — the tricks a nil bidder takes still count toward the team total."
+        />
+        <BidStatCell
+          label="Avg Bags"
+          value={bidStats.avgBags.toFixed(1)}
+          color="#d97706"
+          tooltip="Your team's average bags per round — tricks taken beyond your combined contract, counted only when the team makes its bid (a set or a double-nil round produces no bags). Bags are a team quantity — 10 accumulated bags cost 100 points — so this is measured per team-round. Nil hands are included."
         />
         <BidStatCell
           label="Set Rate"
           value={`${bidStats.setBidRate}%`}
           color="#dc2626"
-          tooltip="Percent of rounds where your team was set — you and your partner's combined tricks fell short of your combined bid. Only rounds where you bid a number (not nil) count toward the denominator. If your partner bid nil, only your bid counts toward the team bid. See Nil Bids below for how nil outcomes are tracked."
+          tooltip="Percent of rounds where your team was set — you and your partner's combined tricks fell short of your combined bid. Every round you played counts, including ones where you or your partner bid nil (a nil counts as 0 toward the combined bid). See Nil Bids below for how nil outcomes are tracked."
         />
       </div>
       <div

--- a/apps/client/src/hooks/use-stats.ts
+++ b/apps/client/src/hooks/use-stats.ts
@@ -27,10 +27,11 @@ export interface PlayerStats {
 
 export interface BidStats {
   totalRounds: number;
-  averageBid: number;
-  averageTricks: number;
-  bidAccuracy: number;
-  underbidRate: number;
+  individualAvgBid: number;
+  teamAvgBid: number;
+  individualAvgTricks: number;
+  teamAvgTricks: number;
+  avgBags: number;
   setBidRate: number;
 }
 

--- a/apps/server/src/db/__tests__/game-results.test.ts
+++ b/apps/server/src/db/__tests__/game-results.test.ts
@@ -413,10 +413,11 @@ describe('game-results', () => {
         rows: [
           {
             total_rounds: '0',
-            avg_bid: '0',
-            avg_tricks: '0',
-            met_bid: '0',
-            over_bid: '0',
+            individual_avg_bid: '0',
+            team_avg_bid: '0',
+            individual_avg_tricks: '0',
+            team_avg_tricks: '0',
+            avg_bags: '0',
             team_set: '0',
           },
         ],
@@ -426,15 +427,16 @@ describe('game-results', () => {
       expect(stats.totalRounds).toBe(0);
     });
 
-    it('should compute bid accuracy and team set rate', async () => {
+    it('should compute individual/team averages, bags, and team set rate', async () => {
       mockQuery.mockResolvedValueOnce({
         rows: [
           {
             total_rounds: '10',
-            avg_bid: '3.5',
-            avg_tricks: '3.8',
-            met_bid: '7',
-            over_bid: '5',
+            individual_avg_bid: '3.5',
+            team_avg_bid: '6.9',
+            individual_avg_tricks: '3.8',
+            team_avg_tricks: '7.2',
+            avg_bags: '1.4',
             team_set: '2',
           },
         ],
@@ -442,11 +444,12 @@ describe('game-results', () => {
 
       const stats = await getBidStats('user-a');
       expect(stats.totalRounds).toBe(10);
-      expect(stats.averageBid).toBe(3.5);
-      expect(stats.averageTricks).toBe(3.8);
-      expect(stats.bidAccuracy).toBe(70); // 7/10 — individual met-or-exceeded-bid
-      expect(stats.underbidRate).toBe(50); // 5/10 (over_bid = underbid in UI terminology)
-      expect(stats.setBidRate).toBe(20); // 2/10 — team set (fewer than the 3 individual sets because partner covered)
+      expect(stats.individualAvgBid).toBe(3.5);
+      expect(stats.teamAvgBid).toBe(6.9);
+      expect(stats.individualAvgTricks).toBe(3.8);
+      expect(stats.teamAvgTricks).toBe(7.2);
+      expect(stats.avgBags).toBe(1.4);
+      expect(stats.setBidRate).toBe(20); // 2/10 team-rounds set
     });
   });
 });

--- a/apps/server/src/db/game-results.ts
+++ b/apps/server/src/db/game-results.ts
@@ -430,28 +430,31 @@ export async function getNilStats(userId: string): Promise<NilStats> {
 
 export interface BidStats {
   totalRounds: number;
-  averageBid: number;
-  averageTricks: number;
-  bidAccuracy: number;
-  underbidRate: number;
+  individualAvgBid: number;
+  teamAvgBid: number;
+  individualAvgTricks: number;
+  teamAvgTricks: number;
+  avgBags: number;
   setBidRate: number;
 }
 
 const EMPTY_BID_STATS: BidStats = {
   totalRounds: 0,
-  averageBid: 0,
-  averageTricks: 0,
-  bidAccuracy: 0,
-  underbidRate: 0,
+  individualAvgBid: 0,
+  teamAvgBid: 0,
+  individualAvgTricks: 0,
+  teamAvgTricks: 0,
+  avgBags: 0,
   setBidRate: 0,
 };
 
 const DEV_SAMPLE_BID_STATS: BidStats = {
   totalRounds: 47,
-  averageBid: 3.4,
-  averageTricks: 3.6,
-  bidAccuracy: 72,
-  underbidRate: 19,
+  individualAvgBid: 3.4,
+  teamAvgBid: 6.9,
+  individualAvgTricks: 3.6,
+  teamAvgTricks: 7.2,
+  avgBags: 1.3,
   setBidRate: 9,
 };
 
@@ -462,32 +465,46 @@ export async function getBidStats(userId: string): Promise<BidStats> {
       : DEV_SAMPLE_BID_STATS;
   }
 
+  // One row per round the player participated in (anchored on their own bid
+  // row, joined to their partner). Nil/blind-nil hands are included — they are
+  // stored as bid 0 (CHECK constraint), so they count as a 0 bid and their
+  // tricks still count toward the team total. Per the team-focus analytics
+  // philosophy, bids/tricks are shown both individually and as a team total,
+  // and bags are reported as a team quantity (the bag penalty is per team).
   const result = await pool.query<{
     total_rounds: string;
-    avg_bid: string;
-    avg_tricks: string;
-    met_bid: string;
-    over_bid: string;
+    individual_avg_bid: string;
+    team_avg_bid: string;
+    individual_avg_tricks: string;
+    team_avg_tricks: string;
+    avg_bags: string;
     team_set: string;
   }>(
     `SELECT
        COUNT(*)::text AS total_rounds,
-       COALESCE(AVG(rb.bid)::numeric(4,1)::text, '0') AS avg_bid,
-       COALESCE(AVG(rb.tricks_won)::numeric(4,1)::text, '0') AS avg_tricks,
-       COUNT(*) FILTER (WHERE rb.tricks_won >= rb.bid)::text AS met_bid,
-       COUNT(*) FILTER (WHERE rb.tricks_won > rb.bid)::text AS over_bid,
+       COALESCE(AVG(rb.bid)::numeric(4,1)::text, '0') AS individual_avg_bid,
+       COALESCE(AVG(rb.bid + partner.bid)::numeric(4,1)::text, '0') AS team_avg_bid,
+       COALESCE(AVG(rb.tricks_won)::numeric(4,1)::text, '0') AS individual_avg_tricks,
+       COALESCE(AVG(rb.tricks_won + partner.tricks_won)::numeric(4,1)::text, '0') AS team_avg_tricks,
+       COALESCE(AVG(
+         CASE
+           -- Double-nil rounds have a 0 contract and never bag (matches scoring.ts)
+           WHEN (rb.bid + partner.bid) = 0 THEN 0
+           -- Bags only accrue when the team makes its combined bid; a set is 0 bags
+           WHEN (rb.tricks_won + partner.tricks_won) >= (rb.bid + partner.bid)
+             THEN (rb.tricks_won + partner.tricks_won) - (rb.bid + partner.bid)
+           ELSE 0
+         END
+       )::numeric(4,1)::text, '0') AS avg_bags,
        COUNT(*) FILTER (
-         WHERE (rb.tricks_won + partner.tricks_won) <
-               (rb.bid + CASE WHEN partner.is_nil OR partner.is_blind_nil THEN 0 ELSE partner.bid END)
+         WHERE (rb.tricks_won + partner.tricks_won) < (rb.bid + partner.bid)
        )::text AS team_set
      FROM round_bids rb
      JOIN round_bids partner
        ON partner.game_result_id = rb.game_result_id
       AND partner.round_number = rb.round_number
       AND partner.player_position = (rb.player_position + 2) % 4
-     WHERE rb.player_id = $1
-       AND NOT rb.is_nil
-       AND NOT rb.is_blind_nil`,
+     WHERE rb.player_id = $1`,
     [userId]
   );
 
@@ -495,16 +512,15 @@ export async function getBidStats(userId: string): Promise<BidStats> {
   const totalRounds = parseInt(row.total_rounds, 10);
   if (totalRounds === 0) return EMPTY_BID_STATS;
 
-  const metBid = parseInt(row.met_bid, 10);
-  const overBid = parseInt(row.over_bid, 10);
   const teamSet = parseInt(row.team_set, 10);
 
   return {
     totalRounds,
-    averageBid: parseFloat(row.avg_bid),
-    averageTricks: parseFloat(row.avg_tricks),
-    bidAccuracy: Math.round((metBid / totalRounds) * 100),
-    underbidRate: Math.round((overBid / totalRounds) * 100),
+    individualAvgBid: parseFloat(row.individual_avg_bid),
+    teamAvgBid: parseFloat(row.team_avg_bid),
+    individualAvgTricks: parseFloat(row.individual_avg_tricks),
+    teamAvgTricks: parseFloat(row.team_avg_tricks),
+    avgBags: parseFloat(row.avg_bags),
     setBidRate: Math.round((teamSet / totalRounds) * 100),
   };
 }


### PR DESCRIPTION
## Summary

Reworks the **Bidding** section of the stats page around the team-focused analytics philosophy established in the recent analytics work (individual trick-vs-bid isn't interpretable — tricks are a team-allocated quantity).

- **Avg Bid** → now shows `individual / team` (you + partner). Nil/blind-nil count as a bid of 0.
- **Avg Tricks** → now shows `individual / team` combined tricks. Nil hands included (a nil bidder's tricks still count for the team).
- **Bid Accuracy** (individual accuracy) → **replaced** with **Avg Bags**, a team-level stat: tricks beyond the combined contract when the team makes its bid. Sets and double-nil rounds produce 0 bags, matching `scoring.ts`.

## Notes

- `getBidStats` no longer excludes nil rounds, so **Set Rate** and all averages are now measured per team-round across *every* round the player participated in (previously nil rounds were dropped from the denominator).
- Double-nil rounds (combined bid 0) are special-cased to 0 bags, matching the game's scoring logic.
- Tooltips updated to explain the `you / team` split and nil handling.

## Testing

- `pnpm build`, `pnpm test` (266 server tests pass), `pnpm lint` (0 errors), `pnpm knip` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)