### PR TITLE
feat(stats): compare bid/trick/bag/set stats against everyone else

### DIFF
--- a/apps/client/src/components/stats/StatsPage.tsx
+++ b/apps/client/src/components/stats/StatsPage.tsx
@@ -441,6 +441,7 @@ function RecentGameRow({ game }: { game: RecentGame }) {
 }
 
 function BiddingSection({ bidStats }: { bidStats: BidStats }) {
+  const o = bidStats.others;
   return (
     <div
       style={{
@@ -479,24 +480,36 @@ function BiddingSection({ bidStats }: { bidStats: BidStats }) {
         <BidStatCell
           label="Avg Bid (you / team)"
           value={`${bidStats.individualAvgBid.toFixed(1)} / ${bidStats.teamAvgBid.toFixed(1)}`}
-          tooltip="Your average bid per round (left) and your team's combined bid — you plus your partner (right). Nil and blind-nil hands count as a bid of 0."
+          sub={
+            o
+              ? `vs others ${o.individualAvgBid.toFixed(1)} / ${o.teamAvgBid.toFixed(1)}`
+              : undefined
+          }
+          tooltip="Your average bid per round (left) and your team's combined bid — you plus your partner (right). Nil and blind-nil hands count as a bid of 0. The comparison line is the same figures for every other player and for every team that didn't include you."
         />
         <BidStatCell
           label="Avg Tricks (you / team)"
           value={`${bidStats.individualAvgTricks.toFixed(1)} / ${bidStats.teamAvgTricks.toFixed(1)}`}
-          tooltip="Your average tricks taken per round (left) and your team's combined tricks (right). Nil hands are included — the tricks a nil bidder takes still count toward the team total."
+          sub={
+            o
+              ? `vs others ${o.individualAvgTricks.toFixed(1)} / ${o.teamAvgTricks.toFixed(1)}`
+              : undefined
+          }
+          tooltip="Your average tricks taken per round (left) and your team's combined tricks (right). Nil hands are included — the tricks a nil bidder takes still count toward the team total. The comparison line is every other player and every team that didn't include you."
         />
         <BidStatCell
           label="Avg Bags"
           value={bidStats.avgBags.toFixed(1)}
           color="#d97706"
-          tooltip="Your team's average bags per round — tricks taken beyond your combined contract, counted only when the team makes its bid (a set or a double-nil round produces no bags). Bags are a team quantity — 10 accumulated bags cost 100 points — so this is measured per team-round. Nil hands are included."
+          sub={o ? `vs other teams ${o.avgBags.toFixed(1)}` : undefined}
+          tooltip="Your team's average bags per round — tricks taken beyond your combined contract, counted only when the team makes its bid (a set or a double-nil round produces no bags). Bags are a team quantity — 10 accumulated bags cost 100 points — so this is measured per team-round. Nil hands are included. The comparison line is the average for every team that didn't include you."
         />
         <BidStatCell
           label="Set Rate"
           value={`${bidStats.setBidRate}%`}
           color="#dc2626"
-          tooltip="Percent of rounds where your team was set — you and your partner's combined tricks fell short of your combined bid. Every round you played counts, including ones where you or your partner bid nil (a nil counts as 0 toward the combined bid). See Nil Bids below for how nil outcomes are tracked."
+          sub={o ? `vs other teams ${o.setBidRate}%` : undefined}
+          tooltip="Percent of rounds where your team was set — you and your partner's combined tricks fell short of your combined bid. Every round you played counts, including ones where you or your partner bid nil (a nil counts as 0 toward the combined bid). The comparison line is the set rate for every team that didn't include you. See Nil Bids below for how nil outcomes are tracked."
         />
       </div>
       <div
@@ -517,11 +530,13 @@ function BidStatCell({
   label,
   value,
   color = '#374151',
+  sub,
   tooltip,
 }: {
   label: string;
   value: string;
   color?: string;
+  sub?: string;
   tooltip?: string;
 }) {
   const [rect, setRect] = useState<DOMRect | null>(null);
@@ -539,6 +554,18 @@ function BidStatCell({
       }}
     >
       <div style={{ fontSize: '20px', fontWeight: 700, color }}>{value}</div>
+      {sub && (
+        <div
+          style={{
+            fontSize: '11px',
+            color: '#9ca3af',
+            marginTop: '2px',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {sub}
+        </div>
+      )}
       <div
         style={{
           fontSize: '12px',

--- a/apps/client/src/hooks/use-stats.ts
+++ b/apps/client/src/hooks/use-stats.ts
@@ -25,6 +25,15 @@ export interface PlayerStats {
   partners: PartnerStats[];
 }
 
+interface BidComparison {
+  individualAvgBid: number;
+  teamAvgBid: number;
+  individualAvgTricks: number;
+  teamAvgTricks: number;
+  avgBags: number;
+  setBidRate: number;
+}
+
 export interface BidStats {
   totalRounds: number;
   individualAvgBid: number;
@@ -33,6 +42,7 @@ export interface BidStats {
   teamAvgTricks: number;
   avgBags: number;
   setBidRate: number;
+  others: BidComparison | null;
 }
 
 export interface NilStats {

--- a/apps/server/src/db/__tests__/game-results.test.ts
+++ b/apps/server/src/db/__tests__/game-results.test.ts
@@ -419,6 +419,14 @@ describe('game-results', () => {
             team_avg_tricks: '0',
             avg_bags: '0',
             team_set: '0',
+            others_ind_rounds: '0',
+            others_individual_avg_bid: '0',
+            others_individual_avg_tricks: '0',
+            others_team_rounds: '0',
+            others_team_avg_bid: '0',
+            others_team_avg_tricks: '0',
+            others_avg_bags: '0',
+            others_team_set: '0',
           },
         ],
       });
@@ -438,6 +446,14 @@ describe('game-results', () => {
             team_avg_tricks: '7.2',
             avg_bags: '1.4',
             team_set: '2',
+            others_ind_rounds: '90',
+            others_individual_avg_bid: '3.1',
+            others_individual_avg_tricks: '3.2',
+            others_team_rounds: '30',
+            others_team_avg_bid: '6.4',
+            others_team_avg_tricks: '6.6',
+            others_avg_bags: '1.9',
+            others_team_set: '6',
           },
         ],
       });
@@ -450,6 +466,41 @@ describe('game-results', () => {
       expect(stats.teamAvgTricks).toBe(7.2);
       expect(stats.avgBags).toBe(1.4);
       expect(stats.setBidRate).toBe(20); // 2/10 team-rounds set
+      expect(stats.others).toEqual({
+        individualAvgBid: 3.1,
+        teamAvgBid: 6.4,
+        individualAvgTricks: 3.2,
+        teamAvgTricks: 6.6,
+        avgBags: 1.9,
+        setBidRate: 20, // 6/30 other team-rounds set
+      });
+    });
+
+    it('should null out the comparison when there is no other-player data', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            total_rounds: '10',
+            individual_avg_bid: '3.5',
+            team_avg_bid: '6.9',
+            individual_avg_tricks: '3.8',
+            team_avg_tricks: '7.2',
+            avg_bags: '1.4',
+            team_set: '2',
+            others_ind_rounds: '0',
+            others_individual_avg_bid: '0',
+            others_individual_avg_tricks: '0',
+            others_team_rounds: '0',
+            others_team_avg_bid: '0',
+            others_team_avg_tricks: '0',
+            others_avg_bags: '0',
+            others_team_set: '0',
+          },
+        ],
+      });
+
+      const stats = await getBidStats('user-a');
+      expect(stats.others).toBeNull();
     });
   });
 });

--- a/apps/server/src/db/game-results.ts
+++ b/apps/server/src/db/game-results.ts
@@ -428,6 +428,20 @@ export async function getNilStats(userId: string): Promise<NilStats> {
   };
 }
 
+// Baseline values to compare a player against: the same six metrics computed
+// over everyone but this player. `individual*` aggregates every round_bids row
+// belonging to another player; `team*`/`avgBags`/`setBidRate` aggregate every
+// team-round whose pair does not include this player. Null when there is no
+// comparison data (e.g. the player is the only one in the DB).
+interface BidComparison {
+  individualAvgBid: number;
+  teamAvgBid: number;
+  individualAvgTricks: number;
+  teamAvgTricks: number;
+  avgBags: number;
+  setBidRate: number;
+}
+
 export interface BidStats {
   totalRounds: number;
   individualAvgBid: number;
@@ -436,6 +450,7 @@ export interface BidStats {
   teamAvgTricks: number;
   avgBags: number;
   setBidRate: number;
+  others: BidComparison | null;
 }
 
 const EMPTY_BID_STATS: BidStats = {
@@ -446,6 +461,7 @@ const EMPTY_BID_STATS: BidStats = {
   teamAvgTricks: 0,
   avgBags: 0,
   setBidRate: 0,
+  others: null,
 };
 
 const DEV_SAMPLE_BID_STATS: BidStats = {
@@ -456,6 +472,14 @@ const DEV_SAMPLE_BID_STATS: BidStats = {
   teamAvgTricks: 7.2,
   avgBags: 1.3,
   setBidRate: 9,
+  others: {
+    individualAvgBid: 3.2,
+    teamAvgBid: 6.6,
+    individualAvgTricks: 3.3,
+    teamAvgTricks: 6.7,
+    avgBags: 1.7,
+    setBidRate: 14,
+  },
 };
 
 export async function getBidStats(userId: string): Promise<BidStats> {
@@ -465,12 +489,21 @@ export async function getBidStats(userId: string): Promise<BidStats> {
       : DEV_SAMPLE_BID_STATS;
   }
 
-  // One row per round the player participated in (anchored on their own bid
-  // row, joined to their partner). Nil/blind-nil hands are included — they are
-  // stored as bid 0 (CHECK constraint), so they count as a 0 bid and their
-  // tricks still count toward the team total. Per the team-focus analytics
-  // philosophy, bids/tricks are shown both individually and as a team total,
-  // and bags are reported as a team quantity (the bag penalty is per team).
+  // Three aggregates in one round trip:
+  //  - `mine`: one row per round the player participated in (anchored on their
+  //    own bid row, joined to their partner).
+  //  - `others_ind`: every round_bids row belonging to another player — the
+  //    individual baseline.
+  //  - `others_team`: every team-round whose pair does not include the player —
+  //    the team baseline. `rb.player_position < 2` keeps one row per team-round
+  //    (positions 0/1 anchor team1/team2; 2/3 are their partners), and
+  //    `IS DISTINCT FROM` keeps rows with a NULL (deleted) player_id.
+  // Nil/blind-nil hands are included throughout — they are stored as bid 0
+  // (CHECK constraint), so they count as a 0 bid and their tricks still count
+  // toward the team total. Per the team-focus analytics philosophy, bids/tricks
+  // are shown both individually and as a team total, and bags are reported as a
+  // team quantity (the bag penalty is per team). The bags CASE matches
+  // scoring.ts: a set or a double-nil round (0 contract) produces no bags.
   const result = await pool.query<{
     total_rounds: string;
     individual_avg_bid: string;
@@ -479,32 +512,90 @@ export async function getBidStats(userId: string): Promise<BidStats> {
     team_avg_tricks: string;
     avg_bags: string;
     team_set: string;
+    others_ind_rounds: string;
+    others_individual_avg_bid: string;
+    others_individual_avg_tricks: string;
+    others_team_rounds: string;
+    others_team_avg_bid: string;
+    others_team_avg_tricks: string;
+    others_avg_bags: string;
+    others_team_set: string;
   }>(
-    `SELECT
-       COUNT(*)::text AS total_rounds,
-       COALESCE(AVG(rb.bid)::numeric(4,1)::text, '0') AS individual_avg_bid,
-       COALESCE(AVG(rb.bid + partner.bid)::numeric(4,1)::text, '0') AS team_avg_bid,
-       COALESCE(AVG(rb.tricks_won)::numeric(4,1)::text, '0') AS individual_avg_tricks,
-       COALESCE(AVG(rb.tricks_won + partner.tricks_won)::numeric(4,1)::text, '0') AS team_avg_tricks,
-       COALESCE(AVG(
-         CASE
-           -- Double-nil rounds have a 0 contract and never bag (matches scoring.ts)
-           WHEN (rb.bid + partner.bid) = 0 THEN 0
-           -- Bags only accrue when the team makes its combined bid; a set is 0 bags
-           WHEN (rb.tricks_won + partner.tricks_won) >= (rb.bid + partner.bid)
-             THEN (rb.tricks_won + partner.tricks_won) - (rb.bid + partner.bid)
-           ELSE 0
-         END
-       )::numeric(4,1)::text, '0') AS avg_bags,
-       COUNT(*) FILTER (
-         WHERE (rb.tricks_won + partner.tricks_won) < (rb.bid + partner.bid)
-       )::text AS team_set
-     FROM round_bids rb
-     JOIN round_bids partner
-       ON partner.game_result_id = rb.game_result_id
-      AND partner.round_number = rb.round_number
-      AND partner.player_position = (rb.player_position + 2) % 4
-     WHERE rb.player_id = $1`,
+    `WITH mine AS (
+       SELECT
+         COUNT(*) AS total_rounds,
+         AVG(rb.bid) AS individual_avg_bid,
+         AVG(rb.bid + partner.bid) AS team_avg_bid,
+         AVG(rb.tricks_won) AS individual_avg_tricks,
+         AVG(rb.tricks_won + partner.tricks_won) AS team_avg_tricks,
+         AVG(
+           CASE
+             WHEN (rb.bid + partner.bid) = 0 THEN 0
+             WHEN (rb.tricks_won + partner.tricks_won) >= (rb.bid + partner.bid)
+               THEN (rb.tricks_won + partner.tricks_won) - (rb.bid + partner.bid)
+             ELSE 0
+           END
+         ) AS avg_bags,
+         COUNT(*) FILTER (
+           WHERE (rb.tricks_won + partner.tricks_won) < (rb.bid + partner.bid)
+         ) AS team_set
+       FROM round_bids rb
+       JOIN round_bids partner
+         ON partner.game_result_id = rb.game_result_id
+        AND partner.round_number = rb.round_number
+        AND partner.player_position = (rb.player_position + 2) % 4
+       WHERE rb.player_id = $1
+     ),
+     others_ind AS (
+       SELECT
+         COUNT(*) AS rounds,
+         AVG(bid) AS individual_avg_bid,
+         AVG(tricks_won) AS individual_avg_tricks
+       FROM round_bids
+       WHERE player_id IS DISTINCT FROM $1
+     ),
+     others_team AS (
+       SELECT
+         COUNT(*) AS rounds,
+         AVG(rb.bid + partner.bid) AS team_avg_bid,
+         AVG(rb.tricks_won + partner.tricks_won) AS team_avg_tricks,
+         AVG(
+           CASE
+             WHEN (rb.bid + partner.bid) = 0 THEN 0
+             WHEN (rb.tricks_won + partner.tricks_won) >= (rb.bid + partner.bid)
+               THEN (rb.tricks_won + partner.tricks_won) - (rb.bid + partner.bid)
+             ELSE 0
+           END
+         ) AS avg_bags,
+         COUNT(*) FILTER (
+           WHERE (rb.tricks_won + partner.tricks_won) < (rb.bid + partner.bid)
+         ) AS team_set
+       FROM round_bids rb
+       JOIN round_bids partner
+         ON partner.game_result_id = rb.game_result_id
+        AND partner.round_number = rb.round_number
+        AND partner.player_position = (rb.player_position + 2) % 4
+       WHERE rb.player_position < 2
+         AND rb.player_id IS DISTINCT FROM $1
+         AND partner.player_id IS DISTINCT FROM $1
+     )
+     SELECT
+       mine.total_rounds::text AS total_rounds,
+       COALESCE(mine.individual_avg_bid::numeric(4,1)::text, '0') AS individual_avg_bid,
+       COALESCE(mine.team_avg_bid::numeric(4,1)::text, '0') AS team_avg_bid,
+       COALESCE(mine.individual_avg_tricks::numeric(4,1)::text, '0') AS individual_avg_tricks,
+       COALESCE(mine.team_avg_tricks::numeric(4,1)::text, '0') AS team_avg_tricks,
+       COALESCE(mine.avg_bags::numeric(4,1)::text, '0') AS avg_bags,
+       mine.team_set::text AS team_set,
+       others_ind.rounds::text AS others_ind_rounds,
+       COALESCE(others_ind.individual_avg_bid::numeric(4,1)::text, '0') AS others_individual_avg_bid,
+       COALESCE(others_ind.individual_avg_tricks::numeric(4,1)::text, '0') AS others_individual_avg_tricks,
+       others_team.rounds::text AS others_team_rounds,
+       COALESCE(others_team.team_avg_bid::numeric(4,1)::text, '0') AS others_team_avg_bid,
+       COALESCE(others_team.team_avg_tricks::numeric(4,1)::text, '0') AS others_team_avg_tricks,
+       COALESCE(others_team.avg_bags::numeric(4,1)::text, '0') AS others_avg_bags,
+       others_team.team_set::text AS others_team_set
+     FROM mine, others_ind, others_team`,
     [userId]
   );
 
@@ -514,6 +605,23 @@ export async function getBidStats(userId: string): Promise<BidStats> {
 
   const teamSet = parseInt(row.team_set, 10);
 
+  const othersIndRounds = parseInt(row.others_ind_rounds, 10);
+  const othersTeamRounds = parseInt(row.others_team_rounds, 10);
+  const othersTeamSet = parseInt(row.others_team_set, 10);
+
+  // Only surface the comparison when there is data on both sides.
+  const others: BidComparison | null =
+    othersIndRounds > 0 && othersTeamRounds > 0
+      ? {
+          individualAvgBid: parseFloat(row.others_individual_avg_bid),
+          teamAvgBid: parseFloat(row.others_team_avg_bid),
+          individualAvgTricks: parseFloat(row.others_individual_avg_tricks),
+          teamAvgTricks: parseFloat(row.others_team_avg_tricks),
+          avgBags: parseFloat(row.others_avg_bags),
+          setBidRate: Math.round((othersTeamSet / othersTeamRounds) * 100),
+        }
+      : null;
+
   return {
     totalRounds,
     individualAvgBid: parseFloat(row.individual_avg_bid),
@@ -522,5 +630,6 @@ export async function getBidStats(userId: string): Promise<BidStats> {
     teamAvgTricks: parseFloat(row.team_avg_tricks),
     avgBags: parseFloat(row.avg_bags),
     setBidRate: Math.round((teamSet / totalRounds) * 100),
+    others,
   };
 }


### PR DESCRIPTION
## Summary

Adds a **"vs others" baseline** under each cell in the Bidding section, so you can see how your numbers stack up against the rest of the player pool.

- **Avg Bid** / **Avg Tricks** — compared against every *other player* (individual) and every *team that didn't include you* (team total).
- **Avg Bags** / **Set Rate** — compared against every *team that didn't include you* (bags and sets are team quantities, so there's no individual baseline).

## Implementation

`getBidStats` now computes three aggregates in a **single round trip** via CTEs:

- `mine` — the player's own stats (unchanged).
- `others_ind` — the individual baseline: every `round_bids` row belonging to another player (`player_id IS DISTINCT FROM $1`).
- `others_team` — the team baseline: every team-round whose pair excludes the player. Deduped to one row per team-round with `player_position < 2` (positions 0/1 anchor team1/team2; 2/3 are their partners), and `IS DISTINCT FROM` so NULL/deleted players are still counted.

The bags `CASE` and team-set logic mirror the player's own query exactly (and `scoring.ts`). `others` is `null` when there's no comparison data, and the UI omits the baseline line in that case.

## Validation

Ran the combined query read-only against production. For a sample player: `o_ind_n = 258 = 86 × 3` confirms the "3 other players per round" individual baseline, and the team baseline (86 opposing team-rounds) lines up. Numbers are sane (e.g. 2.5/5.2 bid vs 2.7/5.4 for others; 1.1 bags vs 1.5).

`pnpm build`, `pnpm test` (268 server tests), `pnpm lint` (0 errors), `pnpm knip` all clean.

## Caveat

Per the team-focus analytics philosophy, these comparisons are directional at the current data volume (small, closed player pool) and become more trustworthy as the DB grows. They're presented as neutral descriptors, not skill judgments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)