### PR TITLE
chore(ci): revert actions/checkout v7 → v6 (#268) [resolver test]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   lint-and-typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
           version: 10
@@ -33,7 +33,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
           version: 10
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
           version: 10


### PR DESCRIPTION
Reverts #268 to empirically test whether the `actions/checkout` bump is related to the Dependabot npm resolution failures.

**Hypothesis under test:** merging #268 coincided with Dependabot rebases starting to fail with `ERR_PNPM_NO_MATCHING_VERSION` for `@types/*` packages fetched from `npm.pkg.github.com`.

**Expectation:** no effect — Dependabot's managed updater reads `.github/dependabot.yml`, not `ci.yml`. After this merges, we'll trigger a rebase on a stuck Dependabot PR; if it still fails, #268 is exonerated.

If exonerated, this revert will itself be reverted (restoring checkout@v7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)