### PR TITLE
fix(deps): pin npm registry to public npm for Dependabot

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
Forces npm resolution to `registry.npmjs.org` so Dependabot stops resolving `@types/*` against a stale GitHub Packages mirror (root cause: the `automatic-github-packages-auth` experiment auto-auths `npm.pkg.github.com`, which returns a ~2022-frozen DefinitelyTyped snapshot → `ERR_PNPM_NO_MATCHING_VERSION`).

**Test plan:** merge → trigger a rebase on a stuck Dependabot PR (#275) → inspect the proxy logs to confirm `@types/*` now resolves via npmjs instead of `npm.pkg.github.com`.

Safe: this repo has no private/GitHub Packages dependencies, so pinning the default registry to public npm is a no-op for local/CI (already the default) and only constrains Dependabot's resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)