### PR TITLE
chore(ci): restore actions/checkout v7 (un-revert #276)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   lint-and-typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
         with:
           version: 10
@@ -33,7 +33,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
         with:
           version: 10
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
         with:
           version: 10


### PR DESCRIPTION
Re-applies the `actions/checkout@v7` bump from #268, which was temporarily reverted in #276 purely to test its relation to the Dependabot resolution failures. That test exonerated it — rebases failed identically with checkout at v6 — and the actual root cause (`automatic-github-packages-auth` resolving `@types/*` against a stale GitHub Packages mirror) was fixed in #277 via a public-npm `.npmrc` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)