### PR TITLE
docs(deps): explain why .npmrc pins public npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,6 @@
+# Pin resolution to public npm. Dependabot's `automatic-github-packages-auth`
+# experiment auto-authenticates npm.pkg.github.com and resolves @types/* against
+# a stale org mirror (frozen ~2022), breaking lockfile regen with
+# ERR_PNPM_NO_MATCHING_VERSION. This repo has no private packages, so forcing the
+# public registry is a safe no-op for normal use but keeps Dependabot working.
 registry=https://registry.npmjs.org/


### PR DESCRIPTION
Adds an inline comment to `.npmrc` documenting why it pins the public npm registry (the `automatic-github-packages-auth` / stale `@types` mirror issue fixed in #277), so the file is self-explanatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)