### PR TITLE
chore(deps): hold @types/node major upgrades for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,18 @@ updates:
         patterns:
           - 'socket.io'
           - 'socket.io-client'
+    ignore:
+      # @types/node majors are upgraded by hand, never by Dependabot, because
+      # the types must match the *deployed* Node runtime — bumping them ahead
+      # of the runtime lets tsc green-light Node APIs that don't exist at
+      # runtime. A Node major upgrade is a coordinated change across
+      # engines.node (package.json), .nvmrc, node-version (ci.yml), and
+      # NODE_VERSION (render.yaml), and we only move to even-numbered LTS
+      # lines. Minor/patch updates within the current major still flow.
+      # (A scheduled routine performs the Node 26 upgrade once 26 is Active
+      # LTS, ~Nov 2026, and removes this ignore as part of that PR.)
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
 
   # GitHub Actions
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
## Why

`@types/node` majors must track the **deployed** Node runtime, not lead it. Bumping the types ahead of the runtime lets `tsc` green-light Node APIs that don't exist at runtime — a bug class CI structurally can't catch (it runs on the real runtime but only exercises code the tests reach). This is exactly the risk flagged on #283 (the held `@types/node` 24 → 26 bump).

## What

Adds a Dependabot `ignore` for `@types/node` `version-update:semver-major` on the npm update block.

- **Minor/patch** `@types/node` updates within the current major still flow normally.
- **Majors** are now Dependabot's job to *not* propose — they're a coordinated manual change across `engines.node` (package.json), `.nvmrc`, `node-version` (ci.yml ×3), and `NODE_VERSION` (render.yaml), and only ever to even-numbered **LTS** lines.

## Follow-up

A one-off scheduled cloud routine is set to perform the Node 26 upgrade once Node 26 reaches **Active LTS** (~Nov 2026). That routine verifies LTS status before acting, does the full coordinated change, and removes this `ignore` in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)