### PR TITLE
fix(deps): bump socket.io-parser to 4.2.7 (GHSA-2m8v-j782-fhvr)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,8 +345,14 @@ After every bug fix or feature implementation:
 2. Commit the changes using the [Conventional Commits](https://www.conventionalcommits.org/) standard. Format: `<type>(<optional scope>): <description>`. Common types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `style`, `perf`, `ci`, `build`. Use `!` after the type/scope for breaking changes (e.g., `feat!: ...`). Include a body for additional context when needed.
 3. **Run all tests locally** to ensure they pass before pushing:
    ```bash
-   pnpm test                    # Run all tests (unit + E2E)
-   pnpm --filter @spades/e2e test  # Run E2E tests only if needed
+   pnpm test                       # Unit tests only — the root script is
+                                   # `pnpm -r --filter '!@spades/e2e' test`,
+                                   # so this does NOT run E2E
+   pnpm --filter @spades/e2e test  # E2E — a separate, required run
    ```
+   Both commands are needed before pushing. `pnpm test` passing is **not**
+   evidence that E2E passed, which matters most for changes to the socket
+   layer, state machine, or reconnect paths — precisely the areas unit tests
+   cover least.
 4. Push the branch and open a PR to merge into `main` using `gh pr create`. Do **not** push directly to `main`.
 5. **Update Documentation**: After successful implementation (all tests pass, PR ready), reflect on what you had to discover or learn during implementation. Update this `CLAUDE.md` file with any patterns, gotchas, or architectural details that would have saved time. This keeps the documentation current and helps future work go faster. Add a `docs(claude): <description>` commit to the same branch before merging.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2435,8 +2435,8 @@ packages:
     resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
     engines: {node: '>=10.0.0'}
 
-  socket.io-parser@4.2.6:
-    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
     engines: {node: '>=10.0.0'}
 
   socket.io@4.8.3:
@@ -5211,13 +5211,13 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@5.5.0)
       engine.io-client: 6.6.5
-      socket.io-parser: 4.2.6
+      socket.io-parser: 4.2.7
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.6:
+  socket.io-parser@4.2.7:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@5.5.0)
@@ -5232,7 +5232,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       engine.io: 6.6.8
       socket.io-adapter: 2.5.7
-      socket.io-parser: 4.2.6
+      socket.io-parser: 4.2.7
     transitivePeerDependencies:
       - bufferutil
       - supports-color


### PR DESCRIPTION
Closes Dependabot alert #38 — [GHSA-2m8v-j782-fhvr](https://github.com/advisories/GHSA-2m8v-j782-fhvr) / CVE-2026-69185, **high** severity.

## The vulnerability

A crafted Socket.IO packet can declare a zero or very large binary-attachment count, making the decoder wait for and buffer attachments that never arrive — exhausting server memory. The advisory lists no workaround other than upgrading.

## Exposure here is real

Unlike the still-open `brace-expansion` alert (#36, dev tooling only), this one sits on the production path. `pnpm why -r --prod socket.io-parser`:

```
@spades/server → socket.io@4.8.3        → socket.io-parser@4.2.6
@spades/client → socket.io-client@4.8.3 → socket.io-parser@4.2.6
```

That is the server's public Socket.io listener on Render, reachable by anyone who can open a socket — before authentication. One vulnerable copy in the lockfile, so one thing to fix.

## Why no `pnpm.overrides` entry

Both `socket.io@4.8.3` and `socket.io-client@4.8.3` declare `socket.io-parser: ~4.2.4` (`>=4.2.4 <4.3.0`), and the patched `4.2.7` is inside that range. `pnpm update -r --depth Infinity socket.io-parser` pulls it on its own — no override, no compatibility risk. This is the in-range case CLAUDE.md describes, not the `ws`/`engine.io` case that needed a forced pin.

The lockfile diff is 5 line pairs, all `socket.io-parser`; no `package.json` change and no unrelated in-range drift.

## One behavioral change, verified inert

4.2.7 adds two decoder guards plus a new `maxAttachments` option **defaulting to 10**:

```js
if (!isInteger(n) || n < 1) throw new Error("Illegal attachments");
else if (n > this.opts.maxAttachments) throw new Error("too many attachments");
```

That default is a real cap, so it was worth confirming it can't bite us. It can't: every socket event in this app is plain JSON (cards, positions, strings, booleans). Grepping the shared types and both socket layers finds no `Buffer`/`ArrayBuffer`/`Blob`/`Uint8Array` payloads, so zero attachments are ever sent. No configuration needed.

## Verification

- `pnpm build` — clean
- `pnpm lint` — 0 errors (63 pre-existing warnings, unchanged)
- `pnpm knip` — clean
- `pnpm test` — 318 unit tests pass
- `pnpm --filter @spades/e2e test` — 40 pass. One flaky on first run, `reconnect.spec.ts:66`; since that is the exact socket path this change touches, I re-ran `tests/reconnect.spec.ts --repeat-each=3 --retries=0` → **15/15 pass**. Contention under the full suite, matching the documented flake history, not a regression.

## Second commit

`docs(claude)` fixes an inaccuracy found while running the above: the workflow section claimed `pnpm test` runs "unit + E2E", but the root script is `pnpm -r --filter '!@spades/e2e' test`. Following the old wording would let a socket-layer change ship with no E2E coverage while looking fully tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)