### PR TITLE
feat(ai): move bid advisor to claude-sonnet-5

### DIFF
--- a/apps/server/src/ai/claude-service.ts
+++ b/apps/server/src/ai/claude-service.ts
@@ -2,7 +2,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import type { Card, Position } from '@spades/shared';
 
 const MODEL_HAIKU = 'claude-haiku-4-5';
-const MODEL_SONNET = 'claude-sonnet-4-6';
+const MODEL_SONNET = 'claude-sonnet-5';
 
 /**
  * Voices for the post-game writeup. One is chosen at random per game so the
@@ -314,7 +314,16 @@ export async function generateBidAdvice(data: {
   try {
     const response = await anthropic.messages.create({
       model: MODEL_SONNET,
-      max_tokens: 1024,
+      // Sonnet 5 turns adaptive thinking ON when `thinking` is omitted (4.6 ran
+      // thinking-off by omission), and thinking tokens count against max_tokens.
+      // Left implicit, thinking could crowd out the forced tool_use block, which
+      // fails *silently*: the `toolUse` lookup below returns undefined and bid
+      // advice disappears with only a console.warn. Disabled here to preserve
+      // 4.6 latency and semantics exactly — see PR for the adaptive alternative.
+      thinking: { type: 'disabled' as const },
+      // 1024 -> 2048: Sonnet 5's tokenizer yields ~30% more tokens for the same
+      // text, so the old ceiling is effectively tighter than it was on 4.6.
+      max_tokens: 2048,
       system: `You are a Spades bidding advisor. You will be given a hand of exactly 13 cards. Your job is to recommend a bid and provide a brief explanation. Do not reference any card not in the hand you are given.
 
 ## Bidding Rules


### PR DESCRIPTION
Follow-up from the dependency review on #339. Bumps `MODEL_SONNET` from `claude-sonnet-4-6` (previous-generation Sonnet) to `claude-sonnet-5`.

### Scope correction

My review comment on #339 described this constant as backing "the recap generation." That was wrong. `MODEL_SONNET` is used at exactly one call site — `generateBidAdvice()`. The post-game recap (`generateGameSummary`) and team-name generation (`generateTeamNames`) both run on `MODEL_HAIKU` and are untouched by this PR. So this affects **in-game bid advice**, which is the more reasoning-sensitive of the two paths.

### Why this isn't just a model-string swap

The bid-advice request omitted `thinking` and set `max_tokens: 1024`. Two Sonnet 5 changes interact badly with that:

1. **Adaptive thinking is on by default when `thinking` is omitted.** On Sonnet 4.6 the same request ran with no thinking at all. Thinking tokens count against `max_tokens`.
2. **New tokenizer, ~30% more tokens for the same text**, so the old ceiling is effectively tighter than it was.

That combination has a genuinely nasty failure mode here, because the call forces `tool_choice: { type: 'tool', name: 'recommend_bid' }` and then reads the `tool_use` block back out:

```ts
const toolUse = response.content.find((block) => block.type === 'tool_use');
if (toolUse?.type !== 'tool_use') {
  console.warn('[ai] No tool use found in bid advice response');
  return null;
}
```

If thinking crowds out that block, `generateBidAdvice` returns `null` and bid advice **silently disappears in production** — one `console.warn` and nothing else. And nothing in CI would catch it: `claude-service.test.ts` does `vi.mock('@anthropic-ai/sdk')`, and `getClient()` returns `null` without `ANTHROPIC_API_KEY`, which CI doesn't set. The SDK is never actually invoked in any job.

So this PR also:

- pins `thinking: { type: 'disabled' }`, preserving 4.6's latency and semantics exactly
- raises `max_tokens` 1024 → 2048 for the tokenizer inflation

No sampling parameters were in use anywhere in the file (Sonnet 5 rejects non-default `temperature`/`top_p`/`top_k` with a 400), so nothing else in the request needed changing.

### The alternative, if you'd rather have the reasoning

Disabling thinking is the conservative reading of "bump the model" — it keeps the request behaving as it does today. The documented recommendation when migrating a thinking-off 4.6 workload is instead adaptive thinking at low effort:

```ts
thinking: { type: 'adaptive' },
output_config: { effort: 'low' },
max_tokens: 4096,
```

For a hand-evaluation task against a detailed rubric that would plausibly improve advice quality, at the cost of added latency on a live in-game turn and more tokens per call. I didn't default to it because bid advice renders during a player's turn and the failure mode above is silent. Easy to flip if you'd prefer it — say the word and I'll push the change.

### Verification

- `pnpm build` — clean (`tsc` across all packages)
- `pnpm test` — 145/145 server tests pass (318 total across the monorepo)
- `pnpm lint` — 0 errors (63 pre-existing warnings, unchanged)
- `pnpm knip` — clean

**Not verified, and not verifiable in CI:** the actual request/response round trip against a live API. Both the model bump and the `thinking`/`max_tokens` change only take effect where `ANTHROPIC_API_KEY` is set, i.e. the deployed Render service. Worth watching the first few bid-advice requests after deploy for `[ai] No tool use found in bid advice response` in the logs — that line is the canary for the truncation scenario described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)