### PR TITLE
chore(deps-dev): bump @types/pg from 8.20.3 to 8.21.0

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^24.13.3",
     "@types/passport": "^1.0.17",
     "@types/passport-google-oauth20": "^2.0.16",
-    "@types/pg": "^8.20.3",
+    "@types/pg": "^8.21.0",
     "nodemon": "^3.1.14",
     "socket.io-client": "^4.8.3",
     "tsx": "^4.23.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,8 +149,8 @@ importers:
         specifier: ^2.0.16
         version: 2.0.17
       '@types/pg':
-        specifier: ^8.20.3
-        version: 8.20.3
+        specifier: ^8.21.0
+        version: 8.21.0
       nodemon:
         specifier: ^3.1.14
         version: 3.1.14
@@ -956,8 +956,8 @@ packages:
   '@types/passport@1.0.17':
     resolution: {integrity: sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==}
 
-  '@types/pg@8.20.3':
-    resolution: {integrity: sha512-4Tvg+HO6+oQaAkpT8GTYoSExzpGGZz532GXgbbCElWJQeQdMozBWxEKNBhJJpHFjWXsMxqPbyypvj/89FWNoSQ==}
+  '@types/pg@8.21.0':
+    resolution: {integrity: sha512-AYdtudzabjLZgVgRZmAnU8bAnVUXzuJX2IYHeSIiIHm68olD+LgQYCGWdtcNYnP0uq9c4S4NibVG3Ni7VbKW7Q==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -3336,7 +3336,7 @@ snapshots:
     dependencies:
       '@types/express': 5.0.6
       '@types/express-session': 1.19.0
-      '@types/pg': 8.20.3
+      '@types/pg': 8.21.0
 
   '@types/connect@3.4.38':
     dependencies:
@@ -3399,7 +3399,7 @@ snapshots:
     dependencies:
       '@types/express': 5.0.6
 
-  '@types/pg@8.20.3':
+  '@types/pg@8.21.0':
     dependencies:
       '@types/node': 24.13.3
       pg-protocol: 1.15.0


### PR DESCRIPTION
Re-runs the bump from #337 as a normal PR.

### Why this exists

Dependabot opened #337, then **closed it itself** ~3 minutes after #336 merged, with:

> Looks like @types/pg is no longer updatable, so this is no longer needed.

That was spurious. At the time of writing:

- `@types/pg@8.21.0` is still published and holds the `latest` dist-tag
- `main` still resolved `8.20.3` in both `apps/server/package.json` and `pnpm-lock.yaml`

So the update was neither unavailable nor already applied. The timing points at a transient resolution failure during the rebase that followed #336, rather than anything about the package itself. Reopening wasn't an option — Dependabot had already deleted the branch (`head_ref_deleted`) — hence a fresh branch.

### The change

Identical in substance to what #337 proposed: manifest `^8.20.3` → `^8.21.0`, lockfile resolution `8.20.3` → `8.21.0`. The lockfile diff touches nothing else — no incidental re-resolution of unrelated packages.

Types-only devDependency. The runtime `pg` stays at `^8.22.0`, untouched. Consumers are `db/client.ts` (`pg.Pool`), `db/schema.ts` (`createTables()`), and `db/game-results.ts` (`insertGameResult()` / `getPlayerStats()`).

### Verification

- `pnpm build` — clean (`tsc` across all four packages)
- `pnpm test` — 318/318 pass (shared 107, mods 19, client 47, server 145)
- `pnpm lint` — 0 errors (63 pre-existing warnings, unchanged)
- `pnpm knip` — clean
- `pnpm --filter @spades/e2e test` — 41/41 pass

`tsc` is the meaningful signal here: for a `@types/*` bump the only possible breakage is a narrowed or removed definition, and that surfaces at compile time. Types are erased before runtime, so there is no version of this change that passes the build and then breaks the deployed service.

Worth noting so it doesn't read as a mismatch: `@types/pg` 8.21.0 alongside runtime `pg` 8.22.x is normal — DefinitelyTyped version numbers track the API they describe, not the upstream package's release cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)