### PR TITLE
refactor(client): single-source the sessionStorage read/write policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,7 @@ All four player positions (three opponents + the local player) use a consistent 
 
 - **Zustand store** in `apps/client/src/store/game-store.ts`
 - Session persistence uses `sessionStorage` (per-tab, survives page refresh)
+- **All `sessionStorage` access goes through `apps/client/src/store/session-storage.ts`** (`readStorageJson` / `writeStorageJson` / `removeStorageItem`) — never call `sessionStorage` directly from a new call site. That module owns the whole failure policy: the property access itself is guarded (a browser with storage disabled throws a `SecurityError` before `getItem` is ever reached), writes swallow `QuotaExceededError`, and reads return `null` for missing, unparseable, or wrong-shaped values. `readStorageJson` takes a **required** validator callback rather than a bare `<T>` cast — that's what keeps a corrupted entry from reading back as a shape-correct object with `undefined` fields, and it's deliberately not optional so the three call sites (session token, viewed round, debug breadcrumb buffer) can't drift apart again the way they had before #352.
 - Server is authoritative - client state is derived from socket events
 - No optimistic updates - all state changes are server-confirmed
 

--- a/apps/client/src/store/__tests__/game-store-session.test.ts
+++ b/apps/client/src/store/__tests__/game-store-session.test.ts
@@ -8,11 +8,15 @@ import { beforeEach, describe, expect, it } from 'vitest';
 class MemoryStorage {
   private data = new Map<string, string>();
 
+  /** Simulate a full store / private-mode Safari, which throws on write. */
+  failWrites = false;
+
   getItem(key: string): string | null {
     return this.data.get(key) ?? null;
   }
 
   setItem(key: string, value: string): void {
+    if (this.failWrites) throw new DOMException('quota', 'QuotaExceededError');
     this.data.set(key, value);
   }
 
@@ -38,6 +42,7 @@ const {
 
 beforeEach(() => {
   storage.clear();
+  storage.failWrites = false;
   useGameStore.getState().reset();
 });
 
@@ -76,6 +81,43 @@ describe('leaveGameSession', () => {
     leaveGameSession();
 
     expect(loadViewedRound('ABC123')).toBeNull();
+  });
+});
+
+// Every persisted value goes through the shared read/write policy in
+// session-storage.ts, so a corrupt entry reads back as null and an unwritable
+// store is a silent no-op. Before #352 each block rolled its own: saveSession
+// threw on a full store while saveViewedRound swallowed it, and loadSession
+// returned whatever JSON.parse produced while loadViewedRound shape-checked it.
+describe('session persistence is failure-tolerant', () => {
+  it('returns null for a session entry with the wrong shape', () => {
+    storage.setItem('spades_session', JSON.stringify({ roomId: 'ABC123' }));
+    expect(loadSession()).toBeNull();
+  });
+
+  it('returns null for a malformed session entry rather than throwing', () => {
+    storage.setItem('spades_session', 'not json');
+    expect(loadSession()).toBeNull();
+  });
+
+  it('expires a session older than 30 minutes', () => {
+    storage.setItem(
+      'spades_session',
+      JSON.stringify({
+        roomId: 'ABC123',
+        sessionToken: 'token-abc',
+        timestamp: Date.now() - 31 * 60 * 1000,
+      })
+    );
+    expect(loadSession()).toBeNull();
+  });
+
+  it('does not throw when the store rejects the write', () => {
+    storage.failWrites = true;
+    expect(() => {
+      saveSession('ABC123', 'token-abc');
+    }).not.toThrow();
+    expect(loadSession()).toBeNull();
   });
 });
 

--- a/apps/client/src/store/__tests__/session-storage.test.ts
+++ b/apps/client/src/store/__tests__/session-storage.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+// The client tests run in vitest's default node environment, which has no Web
+// Storage, so these install their own. `throwOnAccess` covers the browsers that
+// throw a SecurityError from the property access itself when storage is
+// disabled — the case that has to be handled before getItem is ever reached.
+let throwOnAccess = false;
+let failWrites = false;
+const data = new Map<string, string>();
+
+const stub: Storage = {
+  get length() {
+    return data.size;
+  },
+  key: (i: number) => [...data.keys()][i] ?? null,
+  getItem: (key: string) => data.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    if (failWrites) throw new DOMException('quota', 'QuotaExceededError');
+    data.set(key, value);
+  },
+  removeItem: (key: string) => {
+    if (failWrites) throw new DOMException('quota', 'QuotaExceededError');
+    data.delete(key);
+  },
+  clear: () => data.clear(),
+};
+
+Object.defineProperty(globalThis, 'sessionStorage', {
+  configurable: true,
+  get() {
+    if (throwOnAccess) throw new DOMException('denied', 'SecurityError');
+    return stub;
+  },
+});
+
+const { readStorageJson, writeStorageJson, removeStorageItem } =
+  await import('../session-storage');
+
+interface Entry {
+  id: string;
+}
+
+function parseEntry(value: unknown): Entry | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const { id } = value as Record<string, unknown>;
+  return typeof id === 'string' ? { id } : null;
+}
+
+beforeEach(() => {
+  data.clear();
+  throwOnAccess = false;
+  failWrites = false;
+});
+
+describe('readStorageJson', () => {
+  it('round-trips a value written by writeStorageJson', () => {
+    writeStorageJson('k', { id: 'abc' });
+    expect(readStorageJson('k', parseEntry)).toEqual({ id: 'abc' });
+  });
+
+  it('returns null when the key is absent', () => {
+    expect(readStorageJson('k', parseEntry)).toBeNull();
+  });
+
+  it('returns null on unparseable JSON', () => {
+    stub.setItem('k', 'not json');
+    expect(readStorageJson('k', parseEntry)).toBeNull();
+  });
+
+  // The drift issue #352 called out: without a mandatory shape check a
+  // corrupted entry reads back as a plausible object with undefined fields.
+  it('returns null when the validator rejects the shape', () => {
+    stub.setItem('k', JSON.stringify({ id: 42 }));
+    expect(readStorageJson('k', parseEntry)).toBeNull();
+  });
+
+  it('returns null when a validator throws', () => {
+    stub.setItem('k', JSON.stringify({ id: 'abc' }));
+    expect(
+      readStorageJson('k', () => {
+        throw new Error('boom');
+      })
+    ).toBeNull();
+  });
+
+  it('returns null when storage access throws', () => {
+    throwOnAccess = true;
+    expect(readStorageJson('k', parseEntry)).toBeNull();
+  });
+});
+
+describe('writeStorageJson', () => {
+  it('swallows a quota error', () => {
+    failWrites = true;
+    expect(() => writeStorageJson('k', { id: 'abc' })).not.toThrow();
+  });
+
+  it('swallows a storage access error', () => {
+    throwOnAccess = true;
+    expect(() => writeStorageJson('k', { id: 'abc' })).not.toThrow();
+  });
+});
+
+describe('removeStorageItem', () => {
+  it('deletes the key', () => {
+    writeStorageJson('k', { id: 'abc' });
+    removeStorageItem('k');
+    expect(readStorageJson('k', parseEntry)).toBeNull();
+  });
+
+  it('swallows a storage access error', () => {
+    throwOnAccess = true;
+    expect(() => removeStorageItem('k')).not.toThrow();
+  });
+});

--- a/apps/client/src/store/game-store.ts
+++ b/apps/client/src/store/game-store.ts
@@ -7,6 +7,11 @@ import type {
   ScoreHistoryEntry,
 } from '@spades/shared';
 import { create } from 'zustand';
+import {
+  readStorageJson,
+  removeStorageItem,
+  writeStorageJson,
+} from './session-storage';
 
 export interface AvailableSeat {
   position: Position;
@@ -111,62 +116,75 @@ const SESSION_KEY = 'spades_session';
 // Keyed by room so a stale entry can't follow the player into a different game.
 const VIEWED_ROUND_KEY = 'spades_viewed_round';
 
+interface StoredSession {
+  roomId: string;
+  sessionToken: string;
+  timestamp: number;
+}
+
+// Sessions older than this are treated as gone; the server's own grace period
+// is much shorter, so a stale token would only fail a reconnect.
+const SESSION_TTL_MS = 30 * 60 * 1000;
+
+function parseStoredSession(value: unknown): StoredSession | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const { roomId, sessionToken, timestamp } = value as Record<string, unknown>;
+  if (
+    typeof roomId !== 'string' ||
+    typeof sessionToken !== 'string' ||
+    typeof timestamp !== 'number'
+  ) {
+    return null;
+  }
+  return { roomId, sessionToken, timestamp };
+}
+
 export function saveSession(roomId: string, sessionToken: string) {
-  sessionStorage.setItem(
-    SESSION_KEY,
-    JSON.stringify({ roomId, sessionToken, timestamp: Date.now() })
-  );
+  writeStorageJson(SESSION_KEY, {
+    roomId,
+    sessionToken,
+    timestamp: Date.now(),
+  });
 }
 
 export function loadSession(): { roomId: string; sessionToken: string } | null {
-  try {
-    const data = sessionStorage.getItem(SESSION_KEY);
-    if (!data) return null;
+  const session = readStorageJson(SESSION_KEY, parseStoredSession);
+  if (!session) return null;
 
-    const session = JSON.parse(data);
-    // Session expires after 30 minutes
-    if (Date.now() - session.timestamp > 30 * 60 * 1000) {
-      sessionStorage.removeItem(SESSION_KEY);
-      return null;
-    }
-
-    return session;
-  } catch {
+  if (Date.now() - session.timestamp > SESSION_TTL_MS) {
+    removeStorageItem(SESSION_KEY);
     return null;
   }
+
+  return { roomId: session.roomId, sessionToken: session.sessionToken };
 }
 
 export function clearSession() {
-  sessionStorage.removeItem(SESSION_KEY);
-  sessionStorage.removeItem(VIEWED_ROUND_KEY);
+  removeStorageItem(SESSION_KEY);
+  removeStorageItem(VIEWED_ROUND_KEY);
+}
+
+function parseViewedRound(
+  value: unknown
+): { roomId: string; roundNumber: number } | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const { roomId, roundNumber } = value as Record<string, unknown>;
+  if (typeof roomId !== 'string' || typeof roundNumber !== 'number') {
+    return null;
+  }
+  return { roomId, roundNumber };
 }
 
 // Not exported: the store's `revealCards` action is the only writer, which is
 // what keeps every reveal path committing the decision. Tests exercise it
 // through `revealCards` + `loadViewedRound` rather than reaching in here.
 function saveViewedRound(roomId: string, roundNumber: number) {
-  try {
-    sessionStorage.setItem(
-      VIEWED_ROUND_KEY,
-      JSON.stringify({ roomId, roundNumber })
-    );
-  } catch {
-    // sessionStorage unavailable or full — the server's own hasViewedCards
-    // record is the primary source; this is only the recovery path.
-  }
+  writeStorageJson(VIEWED_ROUND_KEY, { roomId, roundNumber });
 }
 
 export function loadViewedRound(roomId: string): number | null {
-  try {
-    const data = sessionStorage.getItem(VIEWED_ROUND_KEY);
-    if (!data) return null;
-
-    const parsed = JSON.parse(data);
-    if (parsed?.roomId !== roomId) return null;
-    return typeof parsed.roundNumber === 'number' ? parsed.roundNumber : null;
-  } catch {
-    return null;
-  }
+  const viewed = readStorageJson(VIEWED_ROUND_KEY, parseViewedRound);
+  return viewed?.roomId === roomId ? viewed.roundNumber : null;
 }
 
 /**
@@ -303,23 +321,27 @@ export interface DebugBreadcrumb {
   t: number;
 }
 
+const DEBUG_BUFFER_MAX = 50;
+
+function parseBreadcrumbs(value: unknown): DebugBreadcrumb[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.filter(
+    (entry: unknown): entry is DebugBreadcrumb =>
+      typeof entry === 'object' &&
+      entry !== null &&
+      typeof (entry as DebugBreadcrumb).event === 'string' &&
+      typeof (entry as DebugBreadcrumb).t === 'number'
+  );
+}
+
 export function bufferDebug(entry: DebugBreadcrumb) {
-  try {
-    const raw = sessionStorage.getItem(DEBUG_BUFFER_KEY);
-    const buf: DebugBreadcrumb[] = raw ? JSON.parse(raw) : [];
-    buf.push(entry);
-    sessionStorage.setItem(DEBUG_BUFFER_KEY, JSON.stringify(buf.slice(-50)));
-  } catch {
-    // sessionStorage unavailable or full — debug telemetry is best-effort.
-  }
+  const buffered = readStorageJson(DEBUG_BUFFER_KEY, parseBreadcrumbs) ?? [];
+  buffered.push(entry);
+  writeStorageJson(DEBUG_BUFFER_KEY, buffered.slice(-DEBUG_BUFFER_MAX));
 }
 
 export function drainDebugBuffer(): DebugBreadcrumb[] {
-  try {
-    const raw = sessionStorage.getItem(DEBUG_BUFFER_KEY);
-    sessionStorage.removeItem(DEBUG_BUFFER_KEY);
-    return raw ? JSON.parse(raw) : [];
-  } catch {
-    return [];
-  }
+  const buffered = readStorageJson(DEBUG_BUFFER_KEY, parseBreadcrumbs) ?? [];
+  removeStorageItem(DEBUG_BUFFER_KEY);
+  return buffered;
 }

--- a/apps/client/src/store/session-storage.ts
+++ b/apps/client/src/store/session-storage.ts
@@ -1,0 +1,71 @@
+// Single source of the sessionStorage read/write policy.
+//
+// Every persisted value in this app (the session token, the See Cards
+// decision, the debug breadcrumb buffer) is a recovery aid rather than
+// load-bearing state, so storage access is uniformly best-effort: nothing here
+// throws, and a value that isn't there — or isn't what we wrote — reads back as
+// null. Three things can go wrong, and each one used to be handled differently
+// depending on which hand-rolled block you landed in (issue #352):
+//
+//   - Storage is absent or blocked. Touching `sessionStorage` itself throws a
+//     SecurityError when a browser has storage disabled, so even the property
+//     access is guarded; the client's vitest environment simply has no Storage.
+//   - `setItem` throws QuotaExceededError when the store is full (or, in
+//     Safari private mode historically, always).
+//   - The stored JSON is corrupt or has the wrong shape, e.g. written by an
+//     older build of the app.
+
+function getStorage(): globalThis.Storage | null {
+  try {
+    return globalThis.sessionStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read `key`, parse it as JSON, and hand the result to `validate` to narrow it
+ * to the caller's shape. Returns null when the key is missing, the value is
+ * unparseable, or `validate` rejects it.
+ *
+ * The validator is a required argument on purpose: it's the shape check that
+ * keeps a corrupted entry from surfacing as a plausible-looking object with
+ * undefined fields, and making it optional invites exactly the drift this
+ * module exists to prevent.
+ */
+export function readStorageJson<T>(
+  key: string,
+  validate: (value: unknown) => T | null
+): T | null {
+  const storage = getStorage();
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(key);
+    if (raw === null) return null;
+    return validate(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+/** Serialize `value` to `key`. Silently does nothing if storage rejects it. */
+export function writeStorageJson(key: string, value: unknown): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Quota exceeded, or storage unavailable — see the module comment.
+  }
+}
+
+/** Delete `key`. Silently does nothing if storage is unavailable. */
+export function removeStorageItem(key: string): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(key);
+  } catch {
+    // See the module comment.
+  }
+}


### PR DESCRIPTION
Closes #352.

`game-store.ts` had three hand-rolled `sessionStorage` + JSON blocks whose error handling had already drifted:

- `saveSession` threw on a full/unavailable store; `saveViewedRound` swallowed it.
- `loadSession` returned whatever `JSON.parse` produced (a corrupted entry yielded a session-shaped object with `undefined` fields); `loadViewedRound` shape-validated.

## What changed

New `apps/client/src/store/session-storage.ts` owns the policy once:

- `readStorageJson(key, validate)` — returns `null` for missing, unparseable, or rejected values. The validator is a **required** argument rather than a bare `<T>` cast, so no call site can skip the shape check and reintroduce the drift.
- `writeStorageJson(key, value)` — swallows `QuotaExceededError`.
- `removeStorageItem(key)`.
- The `sessionStorage` property access itself is guarded, not just the method calls: a browser with storage disabled throws a `SecurityError` before `getItem` is ever reached.

The three call sites (session token, viewed round, debug breadcrumb buffer) keep their own shape validation on top and behave the same, with two deliberate improvements:

- `loadSession` now returns `null` for an entry missing `roomId`/`sessionToken`/a numeric `timestamp`, instead of an object with `undefined` fields.
- `saveSession` no longer throws when the store rejects the write.

## Tests

- New `session-storage.test.ts`: round-trip, missing key, malformed JSON, rejected shape, throwing validator, storage-access `SecurityError`, quota-exceeded writes.
- `game-store-session.test.ts` gains a `session persistence is failure-tolerant` block covering the two drift cases the issue names, plus session expiry.

`pnpm build`, `pnpm test` (347 unit tests), `pnpm lint` (0 errors), `pnpm knip` (clean), and `pnpm --filter @spades/e2e test` (42 passed) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)