### PR TITLE
fix(auth): make ALLOWED_EMAILS case-insensitive, and document authorizing a new user

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,17 +314,19 @@ pnpm --filter @spades/e2e test filename.spec.ts   # Single file
 
 **Render.yaml DB wiring:** The `DATABASE_URL` env var is populated from `fromDatabase.property: connectionString` (Render's built-in linking). All OAuth secrets (`GOOGLE_CLIENT_ID`, etc.) are `sync: false` — set them manually in the Render dashboard to avoid committing secrets.
 
+**`ALLOWED_EMAILS` is case-sensitive and read once at boot:** `configurePassport()` parses the variable into `allowedEmails` at startup (split/trim/filter), so a changed value needs a process restart — editing it in the Render dashboard triggers a redeploy, which covers that. The comparison is `allowedEmails.includes(email)` where `email` has been lowercased from the Google profile but the allowlist entries have **not**, so any uppercase in the env var silently never matches. An **empty** value disables the allowlist entirely (`allowedEmails.length > 0 &&` short-circuits) rather than locking everyone out. Adding a player also requires a second, separate step in Google Cloud Console while the OAuth app is in Testing status — the full runbook is [Managing Authorized Users](DEPLOYMENT.md#managing-authorized-users) in `DEPLOYMENT.md`.
+
 **Callback URL / trust proxy:** The passport strategy uses `callbackURL: '/auth/google/callback'` (a relative path). Passport constructs the full URL from the request's `Host` and `X-Forwarded-Proto` headers, so the same code works for any deployment — main app, preview apps, etc. — without a `GOOGLE_CALLBACK_URL` env var. `app.set('trust proxy', 1)` is required so Render's load balancer's `X-Forwarded-Proto: https` header is trusted and passport builds `https://` URLs. Each deployment's callback URL must still be registered as an authorized redirect URI in Google Console.
 
 ### Required Env Vars (production only)
 
-| Variable               | Purpose                                                            |
-| ---------------------- | ------------------------------------------------------------------ |
-| `GOOGLE_CLIENT_ID`     | Google OAuth app client ID                                         |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth app secret                                            |
-| `SESSION_SECRET`       | Signs the session cookie (32+ random chars)                        |
-| `ALLOWED_EMAILS`       | Comma-separated allowlist (e.g. `alice@gmail.com,bob@gmail.com`)   |
-| `DATABASE_URL`         | PostgreSQL connection string (auto-set by Render from DB resource) |
+| Variable               | Purpose                                                                          |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| `GOOGLE_CLIENT_ID`     | Google OAuth app client ID                                                       |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth app secret                                                          |
+| `SESSION_SECRET`       | Signs the session cookie (32+ random chars)                                      |
+| `ALLOWED_EMAILS`       | Comma-separated allowlist, lowercase only (e.g. `alice@gmail.com,bob@gmail.com`) |
+| `DATABASE_URL`         | PostgreSQL connection string (auto-set by Render from DB resource)               |
 
 ## Game Result Tracking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,19 +314,19 @@ pnpm --filter @spades/e2e test filename.spec.ts   # Single file
 
 **Render.yaml DB wiring:** The `DATABASE_URL` env var is populated from `fromDatabase.property: connectionString` (Render's built-in linking). All OAuth secrets (`GOOGLE_CLIENT_ID`, etc.) are `sync: false` — set them manually in the Render dashboard to avoid committing secrets.
 
-**`ALLOWED_EMAILS` is case-sensitive and read once at boot:** `configurePassport()` parses the variable into `allowedEmails` at startup (split/trim/filter), so a changed value needs a process restart — editing it in the Render dashboard triggers a redeploy, which covers that. The comparison is `allowedEmails.includes(email)` where `email` has been lowercased from the Google profile but the allowlist entries have **not**, so any uppercase in the env var silently never matches. An **empty** value disables the allowlist entirely (`allowedEmails.length > 0 &&` short-circuits) rather than locking everyone out. Adding a player also requires a second, separate step in Google Cloud Console while the OAuth app is in Testing status — the full runbook is [Managing Authorized Users](DEPLOYMENT.md#managing-authorized-users) in `DEPLOYMENT.md`.
+**`ALLOWED_EMAILS` is read once at boot:** `configurePassport()` parses the variable into `allowedEmails` at startup (split/trim/lowercase/filter), so a changed value needs a process restart — editing it in the Render dashboard triggers a redeploy, which covers that. Both sides of the `allowedEmails.includes(email)` comparison are lowercased (entries at parse time, the incoming address off the Google profile), so casing in the env var is irrelevant; keep it that way, since a case-sensitive entry locks a user out silently, with no server-side signal distinguishing it from a genuine rejection. An **empty** value disables the allowlist entirely (`allowedEmails.length > 0 &&` short-circuits) rather than locking everyone out. `apps/server/src/auth/__tests__/allowed-emails.test.ts` covers these cases by capturing the strategy's verify callback through a `vi.mock` of `passport-google-oauth20` — extend it rather than reaching into passport's internals. Adding a player also requires a second, separate step in Google Cloud Console while the OAuth app is in Testing status — the full runbook is [Managing Authorized Users](DEPLOYMENT.md#managing-authorized-users) in `DEPLOYMENT.md`.
 
 **Callback URL / trust proxy:** The passport strategy uses `callbackURL: '/auth/google/callback'` (a relative path). Passport constructs the full URL from the request's `Host` and `X-Forwarded-Proto` headers, so the same code works for any deployment — main app, preview apps, etc. — without a `GOOGLE_CALLBACK_URL` env var. `app.set('trust proxy', 1)` is required so Render's load balancer's `X-Forwarded-Proto: https` header is trusted and passport builds `https://` URLs. Each deployment's callback URL must still be registered as an authorized redirect URI in Google Console.
 
 ### Required Env Vars (production only)
 
-| Variable               | Purpose                                                                          |
-| ---------------------- | -------------------------------------------------------------------------------- |
-| `GOOGLE_CLIENT_ID`     | Google OAuth app client ID                                                       |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth app secret                                                          |
-| `SESSION_SECRET`       | Signs the session cookie (32+ random chars)                                      |
-| `ALLOWED_EMAILS`       | Comma-separated allowlist, lowercase only (e.g. `alice@gmail.com,bob@gmail.com`) |
-| `DATABASE_URL`         | PostgreSQL connection string (auto-set by Render from DB resource)               |
+| Variable               | Purpose                                                                            |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| `GOOGLE_CLIENT_ID`     | Google OAuth app client ID                                                         |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth app secret                                                            |
+| `SESSION_SECRET`       | Signs the session cookie (32+ random chars)                                        |
+| `ALLOWED_EMAILS`       | Comma-separated allowlist, case-insensitive (e.g. `alice@gmail.com,bob@gmail.com`) |
+| `DATABASE_URL`         | PostgreSQL connection string (auto-set by Render from DB resource)                 |
 
 ## Game Result Tracking
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -53,6 +53,14 @@ Deploy at `yourdomain.com/spades`
    - `SERVE_CLIENT` = `true`
    - `BASE_PATH` = `/` (or `/spades` if using path deployment)
    - `NODE_ENV` = `production`
+   - `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` — from the Google OAuth client
+   - `SESSION_SECRET` — 32+ random characters, signs the session cookie
+   - `ALLOWED_EMAILS` — see [Managing Authorized Users](#managing-authorized-users)
+   - `ANTHROPIC_API_KEY` — optional; without it the team-name feature is inert
+
+   These are all declared `sync: false` in `render.yaml`, meaning Render expects
+   them from the dashboard and they are deliberately not in git. `DATABASE_URL`
+   is the exception — Render populates it from the linked `spades-db` resource.
 
 6. **Deploy**: Click "Create Web Service"
 
@@ -96,6 +104,74 @@ location /spades {
 ProxyPass /spades https://spades-game.onrender.com/spades
 ProxyPassReverse /spades https://spades-game.onrender.com/spades
 ```
+
+## Managing Authorized Users
+
+Access is gated in **two independent places**, and a new player must be added to
+both. Neither is a code change — both are dashboard settings, so there is no
+commit and no PR involved.
+
+### 1. Google Cloud Console — test users
+
+Only required while the OAuth app's publishing status is **Testing**. Go to
+[console.cloud.google.com](https://console.cloud.google.com/) → your project →
+**APIs & Services** → **OAuth consent screen** → **Audience**.
+
+- **Publishing status: Testing** → under **Test users**, click **+ Add users**,
+  enter the address, **Save**. Google caps this list at 100 users.
+- **Publishing status: In production** → nothing to do here. Any Google account
+  can reach the consent screen, and `ALLOWED_EMAILS` is the only gate.
+
+### 2. Render — the `ALLOWED_EMAILS` allowlist
+
+[dashboard.render.com](https://dashboard.render.com/) → the **spades-game**
+service → **Environment** → edit `ALLOWED_EMAILS`, append `,new@example.com`
+to the existing comma-separated list → **Save**.
+
+Two non-obvious constraints, both from `configurePassport()` in
+`apps/server/src/auth/passport-config.ts`:
+
+- **Entries must be lowercase.** The verify callback lowercases the address
+  Google returns (`profile.emails[0].value.toLowerCase()`) but does _not_
+  lowercase the allowlist it compares against, so `Bob@Gmail.com` in the env var
+  will never match. Whitespace around commas is fine — entries are trimmed.
+- **A restart is required.** `allowedEmails` is parsed once, when
+  `configurePassport()` runs at boot, not per login request. Saving an
+  environment variable in Render triggers a redeploy, which satisfies this —
+  but the change is not live until that redeploy finishes.
+
+Note also that an **empty** `ALLOWED_EMAILS` disables the allowlist entirely
+(`allowedEmails.length > 0 &&` short-circuits), letting any Google account in.
+Clearing the variable is not a way to lock the app down.
+
+### Verifying, and reading a failure
+
+Once the redeploy is green, have the new player sign in. Where it breaks tells
+you which half is wrong:
+
+| Symptom                                                                           | Cause                                                             |
+| --------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Google's own "app hasn't completed verification" / "you don't have access" screen | Step 1 — not on the test-user list                                |
+| Google sign-in succeeds, then bounces back to the login gate                      | Step 2 — missing from `ALLOWED_EMAILS`, or a casing/typo mismatch |
+| Everyone is locked out after an edit                                              | Malformed list, or the redeploy hasn't finished                   |
+
+Server-side, a rejected address fails the strategy with `{ message: 'not_allowed' }`
+before any database write, so a blocked user never gets a `users` row.
+
+### Removing a user
+
+Delete the address from `ALLOWED_EMAILS` (and from the Google test-user list if
+in Testing) and let the redeploy land. Their existing session cookie stays valid
+until it expires — the allowlist is only consulted during the OAuth verify
+callback, not on `deserializeUser`. Delete their row from the `users` table to
+force a re-login; the `game_results` player columns are
+`ON DELETE SET NULL`, so past games survive.
+
+### Local development
+
+None of this applies locally. When `NODE_ENV !== 'production'` the server injects
+`DEV_USER` into every request and skips the Socket.io auth check entirely, so
+`pnpm dev` needs no Google credentials, no database, and no allowlist.
 
 ## Local Production Testing
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -128,17 +128,17 @@ Only required while the OAuth app's publishing status is **Testing**. Go to
 service → **Environment** → edit `ALLOWED_EMAILS`, append `,new@example.com`
 to the existing comma-separated list → **Save**.
 
-Two non-obvious constraints, both from `configurePassport()` in
+One non-obvious constraint, from `configurePassport()` in
 `apps/server/src/auth/passport-config.ts`:
 
-- **Entries must be lowercase.** The verify callback lowercases the address
-  Google returns (`profile.emails[0].value.toLowerCase()`) but does _not_
-  lowercase the allowlist it compares against, so `Bob@Gmail.com` in the env var
-  will never match. Whitespace around commas is fine — entries are trimmed.
 - **A restart is required.** `allowedEmails` is parsed once, when
   `configurePassport()` runs at boot, not per login request. Saving an
   environment variable in Render triggers a redeploy, which satisfies this —
   but the change is not live until that redeploy finishes.
+
+Casing and surrounding whitespace do not matter: entries are trimmed and
+lowercased at parse time, and the address from Google is lowercased too, so
+` Bob@Gmail.com` and `bob@gmail.com` are equivalent.
 
 Note also that an **empty** `ALLOWED_EMAILS` disables the allowlist entirely
 (`allowedEmails.length > 0 &&` short-circuits), letting any Google account in.
@@ -149,11 +149,11 @@ Clearing the variable is not a way to lock the app down.
 Once the redeploy is green, have the new player sign in. Where it breaks tells
 you which half is wrong:
 
-| Symptom                                                                           | Cause                                                             |
-| --------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| Google's own "app hasn't completed verification" / "you don't have access" screen | Step 1 — not on the test-user list                                |
-| Google sign-in succeeds, then bounces back to the login gate                      | Step 2 — missing from `ALLOWED_EMAILS`, or a casing/typo mismatch |
-| Everyone is locked out after an edit                                              | Malformed list, or the redeploy hasn't finished                   |
+| Symptom                                                                           | Cause                                             |
+| --------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Google's own "app hasn't completed verification" / "you don't have access" screen | Step 1 — not on the test-user list                |
+| Google sign-in succeeds, then bounces back to the login gate                      | Step 2 — missing from `ALLOWED_EMAILS`, or a typo |
+| Everyone is locked out after an edit                                              | Malformed list, or the redeploy hasn't finished   |
 
 Server-side, a rejected address fails the strategy with `{ message: 'not_allowed' }`
 before any database write, so a blocked user never gets a `users` row.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -138,7 +138,7 @@ One non-obvious constraint, from `configurePassport()` in
 
 Casing and surrounding whitespace do not matter: entries are trimmed and
 lowercased at parse time, and the address from Google is lowercased too, so
-` Bob@Gmail.com` and `bob@gmail.com` are equivalent.
+`Bob@Gmail.com` and `bob@gmail.com` are equivalent.
 
 Note also that an **empty** `ALLOWED_EMAILS` disables the allowlist entirely
 (`allowedEmails.length > 0 &&` short-circuits), letting any Google account in.

--- a/apps/server/src/auth/__tests__/allowed-emails.test.ts
+++ b/apps/server/src/auth/__tests__/allowed-emails.test.ts
@@ -1,0 +1,174 @@
+import type { Profile } from 'passport-google-oauth20';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture the verify callback that configurePassport() hands to the strategy,
+// so the allowlist check can be exercised without touching Google or passport's
+// internals.
+type VerifyCallback = (
+  accessToken: string,
+  refreshToken: string,
+  profile: Profile,
+  done: (err: Error | null, user?: unknown, info?: { message: string }) => void
+) => void;
+
+let capturedVerify: VerifyCallback | undefined;
+
+/**
+ * Hands back the verify callback captured by the most recent
+ * `configurePassport()` and clears it, so a run that failed to capture one
+ * throws rather than silently reusing the previous test's callback.
+ */
+function takeVerify(): VerifyCallback {
+  const verify = capturedVerify;
+  capturedVerify = undefined;
+  if (!verify) throw new Error('verify callback was never captured');
+  return verify;
+}
+
+vi.mock('passport-google-oauth20', () => ({
+  Strategy: class {
+    name = 'google';
+    constructor(_options: unknown, verify: VerifyCallback) {
+      capturedVerify = verify;
+    }
+  },
+}));
+
+vi.mock('passport', () => ({
+  default: {
+    use: vi.fn(),
+    serializeUser: vi.fn(),
+    deserializeUser: vi.fn(),
+  },
+}));
+
+const query = vi.fn();
+vi.mock('../../db/client.js', () => ({
+  pool: {
+    query: (...args: unknown[]) => query(...args) as unknown,
+  },
+}));
+
+function profileFor(email: string): Profile {
+  return {
+    id: 'google-123',
+    displayName: 'Bob Example',
+    name: { givenName: 'Bob', familyName: 'Example' },
+    emails: [{ value: email, verified: 'true' }],
+    photos: [{ value: 'https://example.com/p.jpg' }],
+  } as unknown as Profile;
+}
+
+interface VerifyResult {
+  err: Error | null;
+  user?: unknown;
+  info?: { message: string };
+}
+
+/**
+ * Loads a fresh copy of passport-config with the given ALLOWED_EMAILS, runs the
+ * strategy's verify callback against `profile`, and resolves with whatever it
+ * passed to `done`.
+ */
+async function verifyProfile(
+  allowlist: string | undefined,
+  profile: Profile
+): Promise<VerifyResult> {
+  vi.resetModules();
+
+  if (allowlist === undefined) {
+    delete process.env.ALLOWED_EMAILS;
+  } else {
+    process.env.ALLOWED_EMAILS = allowlist;
+  }
+
+  const { configurePassport } = await import('../passport-config.js');
+  configurePassport();
+
+  const verify = takeVerify();
+
+  return new Promise((resolve) => {
+    verify('at', 'rt', profile, (err, user, info) => {
+      resolve({ err, user, info });
+    });
+  });
+}
+
+function verifyEmail(
+  allowlist: string | undefined,
+  email: string
+): Promise<VerifyResult> {
+  return verifyProfile(allowlist, profileFor(email));
+}
+
+describe('ALLOWED_EMAILS allowlist', () => {
+  beforeEach(() => {
+    query.mockReset();
+    query.mockResolvedValue({ rows: [{ id: 'u1', email: 'bob@gmail.com' }] });
+  });
+
+  it('admits an address that matches the allowlist exactly', async () => {
+    const { err, user } = await verifyEmail('bob@gmail.com', 'bob@gmail.com');
+    expect(err).toBeNull();
+    expect(user).toMatchObject({ id: 'u1' });
+  });
+
+  // The regression: entries were compared case-sensitively against an address
+  // that had already been lowercased, so any capital in the env var silently
+  // locked the user out.
+  it('admits when the allowlist entry has different casing', async () => {
+    const { err, user, info } = await verifyEmail(
+      'Bob@Gmail.com',
+      'bob@gmail.com'
+    );
+    expect(info).toBeUndefined();
+    expect(err).toBeNull();
+    expect(user).toMatchObject({ id: 'u1' });
+  });
+
+  it('admits when the incoming address has different casing', async () => {
+    const { err, user } = await verifyEmail('bob@gmail.com', 'BOB@Gmail.com');
+    expect(err).toBeNull();
+    expect(user).toMatchObject({ id: 'u1' });
+  });
+
+  it('tolerates whitespace and mixed casing across a multi-entry list', async () => {
+    const { err, user } = await verifyEmail(
+      'Alice@Example.com ,  BOB@gmail.com , carol@example.com',
+      'bob@gmail.com'
+    );
+    expect(err).toBeNull();
+    expect(user).toMatchObject({ id: 'u1' });
+  });
+
+  it('rejects an address that is not on the allowlist', async () => {
+    const { err, user, info } = await verifyEmail(
+      'alice@example.com',
+      'mallory@example.com'
+    );
+    expect(err).toBeNull();
+    expect(user).toBe(false);
+    expect(info).toEqual({ message: 'not_allowed' });
+    // A rejected user must never reach the users table.
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('admits everyone when the allowlist is empty', async () => {
+    const { err, user } = await verifyEmail('', 'anyone@example.com');
+    expect(err).toBeNull();
+    expect(user).toMatchObject({ id: 'u1' });
+  });
+
+  it('admits everyone when the allowlist is unset', async () => {
+    const { err, user } = await verifyEmail(undefined, 'anyone@example.com');
+    expect(err).toBeNull();
+    expect(user).toMatchObject({ id: 'u1' });
+  });
+
+  it('rejects a profile with no email when an allowlist is set', async () => {
+    const profile = { ...profileFor('x@y.com'), emails: undefined };
+    const { user, info } = await verifyProfile('bob@gmail.com', profile);
+    expect(user).toBe(false);
+    expect(info).toEqual({ message: 'not_allowed' });
+  });
+});

--- a/apps/server/src/auth/passport-config.ts
+++ b/apps/server/src/auth/passport-config.ts
@@ -34,9 +34,12 @@ const DEV_USER: User = {
 export { DEV_USER };
 
 export function configurePassport(): void {
+  // Lowercased to match the address from the Google profile, which is itself
+  // lowercased below. Without this an entry like `Bob@Gmail.com` never matches
+  // and the user is silently locked out.
   const allowedEmails = (process.env.ALLOWED_EMAILS ?? '')
     .split(',')
-    .map((e) => e.trim())
+    .map((e) => e.trim().toLowerCase())
     .filter(Boolean);
 
   passport.use(


### PR DESCRIPTION
## Why

Walking through "add a new email to the authorized users" surfaced that the process was undocumented, and that one of the facts worth documenting was really a bug.

## 1. The fix

`configurePassport()` lowercased the address coming back from Google (`profile.emails[0].value.toLowerCase()`) but parsed `ALLOWED_EMAILS` entries verbatim, so an entry like `Bob@Gmail.com` could never match.

The failure mode is what makes this worth fixing rather than documenting: the user is rejected through the same `{ message: 'not_allowed' }` path as a genuinely unauthorized address, before any database write, so there's no server-side signal distinguishing "typo'd the casing in the env var" from "this person isn't allowed in." The operator sees a player who cannot sign in and nothing to point at.

```diff
-    .map((e) => e.trim())
+    .map((e) => e.trim().toLowerCase())
```

Whitespace was already handled.

### Test coverage

New `apps/server/src/auth/__tests__/allowed-emails.test.ts` drives the **real** verify callback, capturing it via a `vi.mock` of `passport-google-oauth20` rather than reaching into passport's internals. Verified both casing tests fail against the previous implementation:

```
× admits when the allowlist entry has different casing
× tolerates whitespace and mixed casing across a multi-entry list
Tests  2 failed | 6 passed (8)
```

It also pins the surrounding behavior that had no coverage at all: an empty or unset allowlist admits everyone, a rejected address never reaches the `users` table, and a profile with no email is rejected.

## 2. The docs

Adding a player requires changes in **two** dashboards, and nothing in the repo said so. Before this PR, only one of the relevant facts was written down (`ALLOWED_EMAILS` exists and is comma-separated, one row in CLAUDE.md's env table). The Google Cloud Console test-user step appeared in no markdown file at all.

**`DEPLOYMENT.md`** gets a `## Managing Authorized Users` runbook: both steps in order, the one real remaining constraint (`allowedEmails` is parsed once at boot, so the change isn't live until Render's redeploy lands), a symptom table mapping each failure to the step that caused it, plus removal semantics and a note that none of it applies to `pnpm dev`. Its env-var list predates auth entirely, so the Google/session/allowlist vars are added there too.

**`CLAUDE.md`** gets the code-level facts as an Auth gotcha, including the note that an *empty* `ALLOWED_EMAILS` disables the gate rather than closing it — a plausible thing to reach for when trying to lock the app down in a hurry.

## Testing

- `pnpm build` — clean
- `pnpm test` — 355 passed, 19 skipped
- `pnpm --filter @spades/e2e test` — 42 passed
- `pnpm lint` — 0 errors (58 pre-existing warnings, unchanged)
- `pnpm knip` — clean